### PR TITLE
Revert back to nonroot user to avoid permission denied

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,6 @@ FROM quay.io/quarkus/quarkus-distroless-image:1.0
 COPY target/strimzi-drain-cleaner-*-runner /application
 
 EXPOSE 8080
-USER 1001
+USER nonroot
 
 CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]


### PR DESCRIPTION
The full error with user 1001 is:

```
30m         Warning   Failed              pod/strimzi-drain-cleaner-d4f87d846-z8wb6    Error: failed to start container "strimzi-drain-cleaner": Error response from daemon: OCI runtime create failed: container_linux.go:367: starting container process caused: exec: "/application": permission denied: unknown
```

We need to rebuild the official image. You can try the new one from `quay.io/fvaleri/drain-cleaner:latest`.
