### PR TITLE
Add Azure pipelines image build workaround

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,10 @@
 # Based on the Quarkus distroless image
 ###
 FROM quay.io/quarkus/quarkus-distroless-image:1.0
-COPY target/strimzi-drain-cleaner-*-runner /application
+
+# the use of --chown flag is a workaround to this Azure pipelines issue:
+# https://github.com/microsoft/azure-pipelines-tasks/issues/6364
+COPY --chown=nonroot:root target/strimzi-drain-cleaner-*-runner /application
 
 EXPOSE 8080
 USER nonroot


### PR DESCRIPTION
The use of --chown flag is a workaround for this Azure pipelines issue:
https://github.com/microsoft/azure-pipelines-tasks/issues/6364

From this [comment](https://github.com/microsoft/azure-pipelines-tasks/issues/6364#issuecomment-813928404) it looks like there is an alternative way to configure the pipeline that should preserve file permissions. I cannot easily test it, so in the meantime I'm proposing this workaround.

I tested the image build on my machine, but it would be good to rebuild it using the pipeline before merge.

