### PR TITLE
Fix permissions when transferring the Java binaries between build stages

### DIFF
--- a/.azure/build-pipeline.yaml
+++ b/.azure/build-pipeline.yaml
@@ -53,7 +53,9 @@ stages:
               BRANCH: $(Build.SourceBranch)
               MVN_ARGS: "-Dquarkus.native.container-build=true"
             displayName: "Build & Test Java"
-          - publish: $(System.DefaultWorkingDirectory)/target
+          - bash: tar -cvpf target.tar ./target
+            displayName: "Tar the target directory"
+          - publish: $(System.DefaultWorkingDirectory)/target.tar
             artifact: Binary
           - task: PublishTestResults@2
             inputs:
@@ -80,7 +82,9 @@ stages:
             inputs:
               source: current
               artifact: Binary
-              path: $(System.DefaultWorkingDirectory)/target
+              path: $(System.DefaultWorkingDirectory)/
+          - bash: tar -xvf target.tar
+            displayName: "Untar the target directory"
           - bash: ".azure/scripts/container-build.sh"
             env:
               BUILD_REASON: $(Build.Reason)

--- a/.azure/build-pipeline.yaml
+++ b/.azure/build-pipeline.yaml
@@ -53,6 +53,8 @@ stages:
               BRANCH: $(Build.SourceBranch)
               MVN_ARGS: "-Dquarkus.native.container-build=true"
             displayName: "Build & Test Java"
+          # We have to TAR the target directory to maintain the permissions of 
+          # the files which would otherwise change when downloading the artifact
           - bash: tar -cvpf target.tar ./target
             displayName: "Tar the target directory"
           - publish: $(System.DefaultWorkingDirectory)/target.tar

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,9 @@
 ###
 FROM quay.io/quarkus/quarkus-distroless-image:1.0
 
-# the use of --chown flag is a workaround to this Azure pipelines issue:
-# https://github.com/microsoft/azure-pipelines-tasks/issues/6364
-COPY --chown=nonroot:root target/strimzi-drain-cleaner-*-runner /application
+COPY target/strimzi-drain-cleaner-*-runner /application
 
 EXPOSE 8080
-USER nonroot
+USER 1001
 
 CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]


### PR DESCRIPTION
When transferring set of files - such as the whole target directory - between stages, the Azure Publich and Download tasks would change file permissions and for example make executable file non-executable etc. This can cause problems when the are use in the stage which downloaded the artifact. One of the solutions is to tar the whole directory / set of directories and use the tar as the artifact instead of using the whole directory. It makes it harder to browse the artifact in the pipeline UI, but it maintains the permissions.

This PR uses this for the Java binaries. It also removes the changes we have done before trying to solve this - removes the `nonroot` user and removes the `chmod` from the `Dockerfile` file.