### PR TITLE
Add Azure release pipeline

### DIFF
--- a/.azure/build-pipeline.yaml
+++ b/.azure/build-pipeline.yaml
@@ -4,9 +4,6 @@ trigger:
     include:
       - 'main'
       - 'release-*'
-  tags:
-    include:
-      - '*'
 pr:
   autoCancel: true
   branches:
@@ -51,7 +48,7 @@ stages:
             env:
               BUILD_REASON: $(Build.Reason)
               BRANCH: $(Build.SourceBranch)
-              MVN_ARGS: "-Dquarkus.native.container-build=true"
+              MVN_ARGS: "-B -Dquarkus.native.container-build=true"
             displayName: "Build & Test Java"
           # We have to TAR the target directory to maintain the permissions of 
           # the files which would otherwise change when downloading the artifact
@@ -152,7 +149,7 @@ stages:
     dependsOn: 
       - container_build
       - run_systemtest
-    condition: and(succeeded(), or(eq(variables['build.sourceBranch'], 'refs/heads/main'), startsWith(variables['build.sourceBranch'], 'refs/tags/')))
+    condition: and(succeeded(), or(eq(variables['build.sourceBranch'], 'refs/heads/main'), startsWith(variables['build.sourceBranch'], 'refs/heads/release-')))
     jobs:
       - job: 'container_build'
         displayName: 'Tag & Push'

--- a/.azure/build-pipeline.yaml
+++ b/.azure/build-pipeline.yaml
@@ -149,7 +149,7 @@ stages:
     dependsOn: 
       - container_build
       - run_systemtest
-    condition: and(succeeded(), or(eq(variables['build.sourceBranch'], 'refs/heads/main'), startsWith(variables['build.sourceBranch'], 'refs/heads/release-')))
+    condition: and(succeeded(), eq(variables['build.sourceBranch'], 'refs/heads/main'))
     jobs:
       - job: 'container_build'
         displayName: 'Tag & Push'

--- a/.azure/release-pipeline.yaml
+++ b/.azure/release-pipeline.yaml
@@ -1,0 +1,134 @@
+# Triggers
+trigger: none
+pr: none
+
+# Parameters
+parameters:
+- name: releaseVersion
+  displayName: Release Version
+  type: string
+- name: useSuffix
+  displayName: Build suffixed images
+  type: boolean
+  default: true
+- name: releaseSuffix
+  displayName: Release Suffix
+  type: number
+- name: sourcePipelineId
+  displayName: Pipeline ID of the source build
+  type: number
+  default: 36
+  values:
+  - 36
+- name: sourceBuildId
+  displayName: Build ID of the source build
+  type: number
+
+# Stages
+stages:
+  - stage: release_artifacts
+    displayName: Release artifacts for ${{ parameters.releaseVersion }}
+    condition: startsWith(variables['build.sourceBranch'], 'refs/heads/release-')
+    jobs:
+      - job: 'release_artifacts'
+        displayName: 'Release Artifacts'
+        strategy:
+          matrix:
+            'java-11':
+              image: 'Ubuntu-18.04'
+              jdk_version: '11'
+              jdk_path: '/usr/lib/jvm/java-11-openjdk-amd64'
+        # Set timeout for jobs
+        timeoutInMinutes: 60
+        # Base system
+        pool:
+          vmImage: 'Ubuntu-18.04'
+        # Pipeline steps
+        steps:
+          - template: 'templates/setup_java.yaml'
+            parameters:
+              JDK_PATH: $(jdk_path)
+              JDK_VERSION: $(jdk_version)
+          - bash: ".azure/scripts/release-artifacts.sh"
+            env:
+              BUILD_REASON: $(Build.Reason)
+              BRANCH: $(Build.SourceBranch)
+              RELEASE_VERSION: '${{ parameters.releaseVersion }}'
+              MVN_ARGS: '-B'
+            displayName: "Prepare release artifacts"
+          - publish: $(System.DefaultWorkingDirectory)/strimzi-drain-cleaner-${{ parameters.releaseVersion }}.tar.gz
+            artifact: ReleaseTarGzArchive
+          - publish: $(System.DefaultWorkingDirectory)/strimzi-drain-cleaner-${{ parameters.releaseVersion }}.zip
+            artifact: ReleaseZipArchive
+  - stage: containers_publish_with_suffix
+    displayName: Publish Containers for ${{ parameters.releaseVersion }}-${{ parameters.releaseSuffix }}
+    dependsOn: 
+      - release_artifacts
+    condition: and(succeeded(), startsWith(variables['build.sourceBranch'], 'refs/heads/release-'))
+    jobs:
+      - job: 'container_build'
+        displayName: 'Tag & Push'
+        # Set timeout for jobs
+        timeoutInMinutes: 60
+        # Base system
+        pool:
+          vmImage: 'Ubuntu-18.04'
+        # Pipeline steps
+        steps:
+          - template: 'templates/setup_docker.yaml'
+          - task: DownloadPipelineArtifact@2
+            inputs:
+              source: specific
+              artifact: Container
+              path: $(System.DefaultWorkingDirectory)
+              project: strimzi
+              pipeline: '${{ parameters.sourcePipelineId }}'
+              runVersion: specific
+              runId: '${{ parameters.sourceBuildId }}'
+          - ${{ if eq(parameters.useSuffix, true) }}:
+            - bash: ".azure/scripts/release-containers.sh"
+              env:
+                BUILD_REASON: $(Build.Reason)
+                BRANCH: $(Build.SourceBranch)
+                DOCKER_USER: $(QUAY_USER)
+                DOCKER_PASS: $(QUAY_PASS)
+                DOCKER_REGISTRY: "quay.io"
+                DOCKER_ORG: "strimzi"
+                RELEASE_VERSION: '${{ parameters.releaseVersion }}-${{ parameters.releaseSuffix }}'
+              displayName: "Tag & Push container"
+  - stage: containers_publish
+    displayName: Publish Containers for ${{ parameters.releaseVersion }}
+    dependsOn: 
+      - release_artifacts
+      - containers_publish_with_suffix
+    condition: and(succeeded(), startsWith(variables['build.sourceBranch'], 'refs/heads/release-'))
+    jobs:
+      - job: 'container_build'
+        displayName: 'Tag & Push'
+        # Set timeout for jobs
+        timeoutInMinutes: 60
+        # Base system
+        pool:
+          vmImage: 'Ubuntu-18.04'
+        # Pipeline steps
+        steps:
+          - template: 'templates/setup_docker.yaml'
+          - task: DownloadPipelineArtifact@2
+            inputs:
+              source: specific
+              artifact: Container
+              path: $(System.DefaultWorkingDirectory)
+              project: strimzi
+              pipeline: '${{ parameters.sourcePipelineId }}'
+              runVersion: specific
+              runId: '${{ parameters.sourceBuildId }}'
+          - bash: ".azure/scripts/release-containers.sh"
+            env:
+              BUILD_REASON: $(Build.Reason)
+              BRANCH: $(Build.SourceBranch)
+              DOCKER_USER: $(QUAY_USER)
+              DOCKER_PASS: $(QUAY_PASS)
+              DOCKER_REGISTRY: "quay.io"
+              DOCKER_ORG: "strimzi"
+              RELEASE_VERSION: '${{ parameters.releaseVersion }}'
+            displayName: "Tag & Push container"

--- a/.azure/scripts/release-artifacts.sh
+++ b/.azure/scripts/release-artifacts.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+
+echo "Build reason: ${BUILD_REASON}"
+echo "Source branch: ${BRANCH}"
+
+echo "Releasing cartifacts for ${RELEASE_VERSION}"
+
+make release

--- a/.azure/scripts/release-containers.sh
+++ b/.azure/scripts/release-containers.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -e
+
+echo "Build reason: ${BUILD_REASON}"
+echo "Source branch: ${BRANCH}"
+
+echo "Releasing container images for ${RELEASE_VERSION}"
+
+# Tag and Push the container
+echo "Login into Docker Hub ..."
+docker login -u $DOCKER_USER -p $DOCKER_PASS $DOCKER_REGISTRY
+
+export DOCKER_TAG=$RELEASE_VERSION
+
+make docker_load docker_tag docker_push

--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,8 @@ release_version:
 
 release_maven:
 	echo "Update pom versions to $(RELEASE_VERSION)"
-	mvn versions:set -DnewVersion=$(shell echo $(RELEASE_VERSION) | tr a-z A-Z)
-	mvn versions:commit
+	mvn $(MVN_ARGS) versions:set -DnewVersion=$(shell echo $(RELEASE_VERSION) | tr a-z A-Z)
+	mvn $(MVN_ARGS) versions:commit
 
 release_pkg:
 	$(CP) -r ./packaging/install ./

--- a/README.md
+++ b/README.md
@@ -109,114 +109,23 @@ You can easily test how it works:
     * The `kubetl drain` command will wait for the Kafka / ZooKeeper to be drained
     * The Drain Cleaner log should show how it gets the eviction events
     * Strimzi Cluster Operator log should show how it rolls the pods which are being evicted
-    
-## Build 
 
-This project uses [Quarkus, the Supersonic Subatomic Java Framework](https://quarkus.io/).
-It can be build directly using Maven.
-But it also has a simple Make build to make it easier to build the binary and the container image.
+## Getting help
 
-### Running the application in dev mode
+If you encounter any issues while using Strimzi, you can get help using:
 
-You can run the application in dev mode that enables live coding using:
-```shell script
-mvn compile quarkus:dev
-```
+- [#strimzi channel on CNCF Slack](https://slack.cncf.io/)
+- [Strimzi Users mailing list](https://lists.cncf.io/g/cncf-strimzi-users/topics)
+- [GitHub Discussions](https://github.com/strimzi/drain-cleaner/discussions)
 
-### Creating a native executable using Maven
+## Contributing
 
-If you have [GraalVM](https://www.graalvm.org/) installed locally, you can create a native executable using: 
-```shell script
-mvn package -Pnative
-```
+You can contribute by raising any issues you find and/or fixing issues by opening Pull Requests.
+All bugs, tasks or enhancements are tracked as [GitHub issues](https://github.com/strimzi/drain-cleaner/issues).
 
-Or you can run the native executable build for Linux in a container using: 
-```shell script
-mvn package -Pnative -Dquarkus.native.container-build=true
-```
+The [development documentation](./development-docs) describe how to build, test and release Strimzi Drain Cleaner.
 
-This is useful especially when running on other operating systems such as macOS or when you don't have GraalVM installed.
+## License
 
-You can then execute your native executable with: `./target/strimzi-drain-cleaner-1.0.0-SNAPSHOT-runner`.
+Strimzi is licensed under the [Apache License](./LICENSE), Version 2.0
 
-### Creating a native executable using Make
-
-If you have [GraalVM](https://www.graalvm.org/) installed locally, you can create a native executable using: 
-```shell script
-make java_package
-```
-
-Or you can run the native executable build for Linux in a container using: 
-```shell script
-MVN_ARGS=-Dquarkus.native.container-build=true make java_package
-```
-
-This is useful especially when running on other operating systems such as macOS or when you don't have GraalVM installed.
-
-You can then execute your native executable with: `./target/strimzi-drain-cleaner-1.0.0-SNAPSHOT-runner`.
-
-### Building a container image manually
-
-After you have the native executable, you can build the container manually:
-
-```
-docker build -f Dockerfile -t my-registry.tld/my-org/strimzi-drain-cleaner:latest .
-docker push my-registry.tld/my-org/strimzi-drain-cleaner:latest
-```
-
-_Update the container image name to match your own registry / organization etc._
-
-### Building a container image using Make
-
-You can also build the image and push it into the registry using Make:
-
-```
-make docker_build docker_push
-```
-
-You can use the following environment variables to configure where will the image be pushed:
-* `DOCKER_REGISTRY` defines the registry where it will be pushed. 
-  For example `docker.io`.
-* `DOCKER_ORG` defines the organization where it will be pushed. 
-  For example `my-org`.
-* `DOCKER_TAG` defines the tag under which will the image be pushed. 
-
-## Running Systemtests
-
-If you want to ensure that everything works, you can run systemtests using:
-```
-mvn verify -Psystemtest
-```
-
-Before you run the tests, you should be logged in to Kubernetes or Openshift cluster.
-Also, you can specify environment variables, that will be used in the Drain Cleaner deployment file:
-* `DOCKER_REGISTRY` defines the registry from where the image should be pulled.
-  For example `docker.io`.
-* `DOCKER_ORG` defines the organization from where the image should be pulled.
-  For example `my-org`.
-* `DOCKER_TAG` defines the tag which should be used.
-
-## Test
-
-Some unit tests are included.
-You can also test it manually by evicting pods or by posting admission reviews.
-
-### Evicting pods
-
-* Install the Drain Cleaner
-* Proxy to the Kubernetes API server
-  ```
-  kubectl proxy
-  ```
-* Use `curl` to trigger eviction _(change pod name and namespace as needed)_:
-  ```
-  curl -v -H 'Content-type: application/json' http://localhost:8001/api/v1/namespaces/myproject/pods/my-cluster-zookeeper-1/eviction -d @src/test/resources/example-eviction-request.json
-  ```
-
-### Posting admission review requests
-
-* Run Drain Cleaner locally (`mvn compile quarkus:dev`)
-* Use `curl` to post the Admission Review Request manually:
-  ```
-  curl -v -H 'Content-type: application/json' http://localhost:8080/drainer -d @src/test/resources/example-admission-review.json
-  ```

--- a/development-docs/DEVELOPING.md
+++ b/development-docs/DEVELOPING.md
@@ -1,0 +1,72 @@
+# Developing Drain Cleaner
+
+## Build
+
+This project uses [Quarkus, the Supersonic Subatomic Java Framework](https://quarkus.io/).
+It can be build directly using Maven.
+But it also has a simple Make build to make it easier to build the binary and the container image.
+
+### Running the application in dev mode
+
+You can run the application in dev mode that enables live coding using:
+```shell script
+mvn compile quarkus:dev
+```
+
+### Creating a native executable using Maven
+
+If you have [GraalVM](https://www.graalvm.org/) installed locally, you can create a native executable using: 
+```shell script
+mvn package -Pnative
+```
+
+Or you can run the native executable build for Linux in a container using: 
+```shell script
+mvn package -Pnative -Dquarkus.native.container-build=true
+```
+
+This is useful especially when running on other operating systems such as macOS or when you don't have GraalVM installed.
+
+You can then execute your native executable with: `./target/strimzi-drain-cleaner-1.0.0-SNAPSHOT-runner`.
+
+### Creating a native executable using Make
+
+If you have [GraalVM](https://www.graalvm.org/) installed locally, you can create a native executable using: 
+```shell script
+make java_package
+```
+
+Or you can run the native executable build for Linux in a container using: 
+```shell script
+MVN_ARGS=-Dquarkus.native.container-build=true make java_package
+```
+
+This is useful especially when running on other operating systems such as macOS or when you don't have GraalVM installed.
+
+You can then execute your native executable with: `./target/strimzi-drain-cleaner-1.0.0-SNAPSHOT-runner`.
+
+### Building a container image manually
+
+After you have the native executable, you can build the container manually:
+
+```
+docker build -f Dockerfile -t my-registry.tld/my-org/strimzi-drain-cleaner:latest .
+docker push my-registry.tld/my-org/strimzi-drain-cleaner:latest
+```
+
+_Update the container image name to match your own registry / organization etc._
+
+### Building a container image using Make
+
+You can also build the image and push it into the registry using Make:
+
+```
+make docker_build docker_push
+```
+
+You can use the following environment variables to configure where will the image be pushed:
+* `DOCKER_REGISTRY` defines the registry where it will be pushed. 
+  For example `docker.io`.
+* `DOCKER_ORG` defines the organization where it will be pushed. 
+  For example `my-org`.
+* `DOCKER_TAG` defines the tag under which will the image be pushed. 

--- a/development-docs/RELEASING.md
+++ b/development-docs/RELEASING.md
@@ -1,0 +1,73 @@
+# Releasing Drain Cleaner
+
+This document describes how to release a new version of the Strimzi Drain Cleaner.
+
+## Regular releases
+
+### Create release branch
+
+Before releasing new major or minor version of Drain Cleaner, the release branch has to be created.
+The release branch should be named as `release-<Major>.<Minor>.x`.
+For example for release 1.2.0, the should be named `release-1.2.x`.
+The release branch is normally created from the `main` branch.
+This is normally done locally and the branch is just pushed into the GitHub repository.
+
+When releasing a new patch version, the release branch should already exist.
+You just need to cherry-pick bug fixes or add them through PRs.
+
+### Prepare the release
+
+For any new release - major, minor or patch - we need to prepare the release.
+The release preparation includes updating the installation files for the new version or changing the version of the Maven project.
+This is implemented in the `Makefiles`, you just need to run the command `RELEASE_VERSION=<NewRealeaseVersion> make release`.
+For example, for release 1.2.0, you would run `RELEASE_VERSION=1.2.0 make release`.
+
+TODO: Copy the install files in Makefiles
+
+Review and commit the changes done by the `make` command and push them into the repository.
+The build pipeline should automatically start for any new commit pushed into the release branch.
+
+### Running the release pipeline
+
+Wait until the build pipeline is (successfully) finished for the last commit in the release branch.
+Then run the release pipeline manually from the Azure Pipelines UI.
+The release pipeline is names `drain-cleaner-release`.
+When starting the new run, it will ask for several parameters which you need to fill:
+
+* Release version (for example `1.2.0`)
+* Release suffix (for example `0` - it is used to create the suffixed images such as `strimzi/drain-cleaner:1.2.0-0` to identify different builds done for example due to base image CVEs)
+* Source pipeline ID (Currently, only the build pipeline with ID `36` can be used)
+* Source build ID (the ID of the build from which the artifacts should be used - use the long build ID from the URL and not the shorter build number)
+
+The release pipeline will push the images to the registry.
+It will also prepare in artifacts the ZIp and TAR.GZ archives with the installation files.
+These will be later attached to the GitHub releases.
+
+### Smoke tests
+
+After the release pipeline is finished, it is always good idea to do some smoke tests of the images to double check they were pushed correctly.
+
+### Creating the release
+
+After the release pipeline is finished, the release has to be created:
+
+* Tag the right commit from the release branch with the release name (e.g. `git tag 1.2.0`) and push it to GitHub
+* On GitHub, create the release and attach the ZIP / TAR.GZ artifacts from the release pipeline to it
+
+### Announcements
+
+Announce the release on following channels:
+* Mailing lists
+* Slack
+* Twitter (if the release is significant enough)
+
+### Release candidates
+
+Release candidates are built with the same release pipeline as the final releases.
+When statrting the pipeline, use the RC name as the release veresion.
+For example `1.2.0-rc1` or `1.2.0-rc2`.
+For release pipelines, you should skip the suffixed build since it is not needed.
+
+When doing the release candidates, the release branch should be already prepared for the final release.
+E.g. when building `1.2.0-rc1`, the release branch should have already the `1.2.0` versions set.
+The release candidate version (e.g. `1.2.0-rc1`) should be used for the GitHub tag and release.

--- a/development-docs/RELEASING.md
+++ b/development-docs/RELEASING.md
@@ -22,8 +22,6 @@ The release preparation includes updating the installation files for the new ver
 This is implemented in the `Makefiles`, you just need to run the command `RELEASE_VERSION=<NewRealeaseVersion> make release`.
 For example, for release 1.2.0, you would run `RELEASE_VERSION=1.2.0 make release`.
 
-TODO: Copy the install files in Makefiles
-
 Review and commit the changes done by the `make` command and push them into the repository.
 The build pipeline should automatically start for any new commit pushed into the release branch.
 

--- a/development-docs/TESTING.md
+++ b/development-docs/TESTING.md
@@ -1,0 +1,43 @@
+# Testing
+
+## Unit Tests
+
+Some unit tests are included and are run automatically during the build.
+You can also run them it manually by evicting pods or by posting admission reviews.
+
+### Evicting pods
+
+* Install the Drain Cleaner
+* Proxy to the Kubernetes API server
+  ```
+  kubectl proxy
+  ```
+* Use `curl` to trigger eviction _(change pod name and namespace as needed)_:
+  ```
+  curl -v -H 'Content-type: application/json' http://localhost:8001/api/v1/namespaces/myproject/pods/my-cluster-zookeeper-1/eviction -d @src/test/resources/example-eviction-request.json
+  ```
+
+### Posting admission review requests
+
+* Run Drain Cleaner locally (`mvn compile quarkus:dev`)
+* Use `curl` to post the Admission Review Request manually:
+  ```
+  curl -v -H 'Content-type: application/json' http://localhost:8080/drainer -d @src/test/resources/example-admission-review.json
+  ```
+
+## System Tests
+
+If you want to ensure that everything works, you can run system tests using:
+
+```
+mvn verify -Psystemtest
+```
+
+Before you run the tests, you should be logged in to Kubernetes or OpenShift cluster.
+
+You can also specify environment variables, that will be used to configure the container image used during the tests:
+* `DOCKER_REGISTRY` defines the registry from where the image should be pulled.
+  For example `docker.io`.
+* `DOCKER_ORG` defines the organization from where the image should be pulled.
+  For example `my-org`.
+* `DOCKER_TAG` defines the tag which should be used.


### PR DESCRIPTION
This PR adds a release pipeline for releases. It also does some smaller changes:
* Refactors the README => the information about building and testing is moved to the `development-docs` folder where the release documentation is
* The build pipeline is changed to not run on tags