### PR TITLE
Changes from strimzi/strimzi-kafka-operator#5560 and additional README.md changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,11 @@
 
 Strimzi Drain Cleaner is an utility which helps with moving the Kafka pods deployed by [Strimzi](https://strimzi.io/) from Kubernetes nodes which are being drained.
 It is useful if you want the Strimzi operator to move the pods instead of Kubernetes itself.
-The advantage of this approach is that the Strimzi operator makes sure that no pods become under-replicated during the node draining.
+The advantage of this approach is that the Strimzi operator makes sure that no partition replicas become under-replicated during the node draining.
 To use it:
 
+* Configure your Kafka topics to have replication factor higher than 1 and make sure the `min.insync.replicas` is always set to a number lower than the replication factor.
+  Availability of topics with replication factor `1` or with `min.insync.replicas` set to the same value as the replication factor will be always affected when the brokers are restarted.
 * Deploy Kafka using Strimzi and configure the `PodDisruptionBudgets` for Kafka and ZooKeeper to have `maxUnavailable` set to `0`.
 This will block Kubernetes from moving the pods on their own.
   

--- a/install/kubernetes/README.md
+++ b/install/kubernetes/README.md
@@ -1,8 +1,8 @@
 # Installing Strimzi Drain Cleaner on Kubernetes without CertManager
 
-Strimzi Drain Cleaner is using `ValidationWebhook` to receive information about Strimzi pods being evicted.
+Strimzi Drain Cleaner uses a `ValidationWebhook` to receive information about Strimzi pods being evicted.
 Kubernetes requires that `ValidationWebhooks` are secured using TLS.
-So the web-hook service need to have HTTPS support.
+So the web-hook service needs to have HTTPS support.
 And the CA of the certificate used for this service needs to be specified in the `ValidatingWebhookConfiguration` resource.
 
 This directory contains sample files with pre-generated certificates.

--- a/install/kubernetes/webhook-certificates/build.sh
+++ b/install/kubernetes/webhook-certificates/build.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+function check_command_present() {
+    command -v "${1}" >/dev/null 2>&1 || { echo -e >&2 "${RED}${1} is required but it's not installed.${NO_COLOUR}"; exit 1; }
+}
+
+check_command_present cfssl
+check_command_present openssl
+
 # Generate CA
 cfssl genkey -initca ca.json | cfssljson -bare ca
 

--- a/packaging/install/kubernetes/README.md
+++ b/packaging/install/kubernetes/README.md
@@ -1,8 +1,8 @@
 # Installing Strimzi Drain Cleaner on Kubernetes without CertManager
 
-Strimzi Drain Cleaner is using `ValidationWebhook` to receive information about Strimzi pods being evicted.
+Strimzi Drain Cleaner uses a `ValidationWebhook` to receive information about Strimzi pods being evicted.
 Kubernetes requires that `ValidationWebhooks` are secured using TLS.
-So the web-hook service need to have HTTPS support.
+So the web-hook service needs to have HTTPS support.
 And the CA of the certificate used for this service needs to be specified in the `ValidatingWebhookConfiguration` resource.
 
 This directory contains sample files with pre-generated certificates.

--- a/packaging/install/kubernetes/webhook-certificates/build.sh
+++ b/packaging/install/kubernetes/webhook-certificates/build.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+function check_command_present() {
+    command -v "${1}" >/dev/null 2>&1 || { echo -e >&2 "${RED}${1} is required but it's not installed.${NO_COLOUR}"; exit 1; }
+}
+
+check_command_present cfssl
+check_command_present openssl
+
 # Generate CA
 cfssl genkey -initca ca.json | cfssljson -bare ca
 


### PR DESCRIPTION
This PR adds the changes from strimzi/strimzi-kafka-operator#5560 to the Drain Cleaner repo. 

It also adds some additional changes to the README.md file:
* Fixes a typo
* Explains that the Drain Cleaner can help only with topics which have the right configuration (RF>1, MINISR<RF) ... it seems some people might think that this is moving the replicas between nodes instead of just monitoring the state of the replicas. So this should make it more clear where it helps.