### PR TITLE
Fixed wrong name for container push job

### DIFF
--- a/.azure/templates/jobs/push_container.yaml
+++ b/.azure/templates/jobs/push_container.yaml
@@ -1,5 +1,5 @@
 jobs:
-  - job: 'container_build'
+  - job: 'push_container'
     displayName: 'Tag & Push'
     # Set timeout for jobs
     timeoutInMinutes: 60


### PR DESCRIPTION
This trivial PR fixes the wrong name for container push job.