### PR TITLE
Updated version of quarkus plugin and quarkus platform which removes CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,10 +19,10 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     
     <!-- Quarkus -->
-    <quarkus-plugin.version>2.2.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>2.2.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
     
     <!-- Other versions -->
     <log4j.version>2.14.1</log4j.version>


### PR DESCRIPTION
This PR updates the version of Quarkus Plugin and Quarkus Platform to 2.4.2 since the previous version of 2.2.2 was bringing in netty 4.7.0.Final which had a CVE