### PR TITLE
Update Quarkus to 2.5.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,10 +19,10 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     
     <!-- Quarkus -->
-    <quarkus-plugin.version>2.4.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.2.Final</quarkus.platform.version>
     
     <!-- Other versions -->
     <log4j.version>2.15.0</log4j.version>


### PR DESCRIPTION
We should do a new patch release of Drain Cleaner with the Log4j2 CVE fix. It makes sense to update Quarkus as well to use the latest version before we do the patch release.