### PR TITLE
STs should use the YAMLs from the packaging/install directory

### DIFF
--- a/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -33,7 +33,7 @@ public class AbstractST {
 
     public static final String NAMESPACE = "strimzi-drain-cleaner";
     public static final String DEPLOYMENT_NAME = "strimzi-drain-cleaner";
-    private static final String INSTALL_PATH = USER_PATH + "/install/kubernetes/";
+    private static final String INSTALL_PATH = USER_PATH + "/packaging/install/kubernetes/";
 
     protected static KubeClusterResource cluster;
     private static Stack<String> createdFiles = new Stack<>();


### PR DESCRIPTION
The under-development YAML files for installation are stored under `packaging/install`. These should be used by the STs, since they contain the latest changes. This was so far not problem, since apart from the image name changed anyway by the operator, these are identical. But we should update it to use the right files for the future.