### PR TITLE
Update to Quarkus 2.5.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,10 +19,10 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     
     <!-- Quarkus -->
-    <quarkus-plugin.version>2.5.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.3.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>2.5.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.3.Final</quarkus.platform.version>
     
     <!-- Other versions -->
     <log4j.version>2.17.0</log4j.version>


### PR DESCRIPTION
Since we are planning a Drain Cleaner release soon, it might make sense to use the latest dependencies. This Pr updates Quarkus to 2.5.3 (currently used 2.5.2).