### PR TITLE
Add basic support for multi-platform builds to our Azure pipelines

### DIFF
--- a/.azure/build-pipeline.yaml
+++ b/.azure/build-pipeline.yaml
@@ -13,58 +13,12 @@ pr:
 # Stages
 stages:
   - stage: java_build
-    displayName: Java
+    displayName: Java build
     jobs:
-      - job: 'build_and_test_java'
-        displayName: 'Build & Test'
-        # Strategy for the job
-        strategy:
-          matrix:
-            'java-11':
-              image: 'Ubuntu-18.04'
-              jdk_version: '11'
-              jdk_path: '/usr/lib/jvm/java-11-openjdk-amd64'
-        # Set timeout for jobs
-        timeoutInMinutes: 60
-        # Base system
-        pool:
-          vmImage: $(image)
-        # Variables
-        variables:
-          MVN_CACHE_FOLDER: $(HOME)/.m2/repository
-          MVN_ARGS: '-e -V -B'
-        # Pipeline steps
-        steps:
-          - task: Cache@2
-            inputs:
-              key: 'mvn-m2-cache | $(System.JobName)'
-              path: "$(MVN_CACHE_FOLDER)"
-            displayName: Maven cache
-          - template: 'templates/steps/setup_java.yaml'
-            parameters:
-              JDK_PATH: $(jdk_path)
-              JDK_VERSION: $(jdk_version)
-          - bash: ".azure/scripts/java-build.sh"
-            env:
-              BUILD_REASON: $(Build.Reason)
-              BRANCH: $(Build.SourceBranch)
-              MVN_ARGS: "-B -Dquarkus.native.container-build=true"
-            displayName: "Build & Test Java"
-          # We have to TAR the target directory to maintain the permissions of 
-          # the files which would otherwise change when downloading the artifact
-          - bash: tar -cvpf target.tar ./target
-            displayName: "Tar the target directory"
-          - publish: $(System.DefaultWorkingDirectory)/target.tar
-            artifact: Binary
-          - task: PublishTestResults@2
-            inputs:
-              testResultsFormat: JUnit
-              testResultsFiles: '**/TEST-*.xml'
-              testRunTitle: "Unit & Integration tests"
-            condition: always()
+      - template: 'templates/jobs/build_java.yaml'
   - stage: container_build
     displayName: Prepare Container
-    dependsOn: 
+    dependsOn:
       - java_build
     jobs:
       - template: 'templates/jobs/build_container.yaml'
@@ -74,8 +28,9 @@ stages:
           artifactPipeline: ''
           artifactRunVersion: ''
           artifactRunId: ''
-  - stage: run_systemtest
-    displayName: Run Systemtests
+          architectures: ['amd64']
+  - stage: run_systemtests
+    displayName: Run System-tests
     dependsOn:
       - container_build
     condition: succeeded()
@@ -84,11 +39,16 @@ stages:
       docker_registry: localhost:5000
     jobs:
       - template: 'templates/jobs/run_systemtests.yaml'
+        parameters:
+          # The system tests should currently always run only amd64 on Azure since we do not have any other environments
+          # available. So when adding support for a new platform, you should not add it here unless you also add the
+          # system tests support for it.
+          architectures: ['amd64']
   - stage: container_publish
     displayName: Publish Container
-    dependsOn: 
+    dependsOn:
       - container_build
-      - run_systemtest
+      - run_systemtests
     condition: and(succeeded(), eq(variables['build.sourceBranch'], 'refs/heads/main'))
     jobs:
       - template: 'templates/jobs/push_container.yaml'
@@ -99,3 +59,4 @@ stages:
           artifactPipeline: ''
           artifactRunVersion: ''
           artifactRunId: ''
+          architectures: ['amd64']

--- a/.azure/cve-pipeline.yaml
+++ b/.azure/cve-pipeline.yaml
@@ -36,8 +36,9 @@ stages:
           artifactPipeline: '${{ parameters.sourcePipelineId }}'
           artifactRunVersion: 'specific'
           artifactRunId: '${{ parameters.sourceBuildId }}'
-  - stage: run_systemtest
-    displayName: Run Systemtests
+          architectures: ['amd64']
+  - stage: run_systemtests
+    displayName: Run System-tests
     dependsOn:
       - container_build
     condition: succeeded()
@@ -46,10 +47,15 @@ stages:
       docker_registry: localhost:5000
     jobs:
       - template: 'templates/jobs/run_systemtests.yaml'
+        parameters:
+          # The system tests should currently always run only amd64 on Azure since we do not have any other environments
+          # available. So when adding support for a new platform, you should not add it here unless you also add the
+          # system tests support for it.
+          architectures: [ 'amd64' ]
   - stage: containers_publish_with_suffix
     displayName: Publish Containers for ${{ parameters.releaseVersion }}-${{ parameters.releaseSuffix }}
     dependsOn: 
-      - run_systemtest
+      - run_systemtests
     condition: and(succeeded(), startsWith(variables['build.sourceBranch'], 'refs/heads/release-'))
     jobs:
       - template: 'templates/jobs/push_container.yaml'
@@ -60,10 +66,11 @@ stages:
           artifactPipeline: ''
           artifactRunVersion: ''
           artifactRunId: ''
+          architectures: ['amd64']
   - stage: manual_validation
     displayName: Validate container before pushing container as ${{ parameters.releaseVersion }}
     dependsOn: 
-      - run_systemtest
+      - run_systemtests
       - containers_publish_with_suffix
     condition: and(succeeded(), startsWith(variables['build.sourceBranch'], 'refs/heads/release-'))
     jobs:
@@ -84,7 +91,7 @@ stages:
     displayName: Publish Containers for ${{ parameters.releaseVersion }}
     dependsOn:
       - manual_validation
-      - run_systemtest
+      - run_systemtests
       - containers_publish_with_suffix
     condition: and(succeeded(), startsWith(variables['build.sourceBranch'], 'refs/heads/release-'))
     jobs:
@@ -96,3 +103,4 @@ stages:
           artifactPipeline: ''
           artifactRunVersion: ''
           artifactRunId: ''
+          architectures: ['amd64']

--- a/.azure/release-pipeline.yaml
+++ b/.azure/release-pipeline.yaml
@@ -35,14 +35,14 @@ stages:
         strategy:
           matrix:
             'java-11':
-              image: 'Ubuntu-18.04'
+              image: 'Ubuntu-20.04'
               jdk_version: '11'
               jdk_path: '/usr/lib/jvm/java-11-openjdk-amd64'
         # Set timeout for jobs
         timeoutInMinutes: 60
         # Base system
         pool:
-          vmImage: 'Ubuntu-18.04'
+          vmImage: 'Ubuntu-20.04'
         # Pipeline steps
         steps:
           - template: 'templates/steps/setup_java.yaml'
@@ -64,7 +64,7 @@ stages:
     displayName: Publish Containers for ${{ parameters.releaseVersion }}-${{ parameters.releaseSuffix }}
     dependsOn: 
       - release_artifacts
-    condition: and(succeeded(), startsWith(variables['build.sourceBranch'], 'refs/heads/release-'))
+    condition: and(succeeded(), startsWith(variables['build.sourceBranch'], 'refs/heads/release-'), eq('${{ parameters.useSuffix }}', 'true'))
     jobs:
       - template: 'templates/jobs/push_container.yaml'
         parameters:
@@ -74,12 +74,13 @@ stages:
           artifactPipeline: '${{ parameters.sourcePipelineId }}'
           artifactRunVersion: 'specific'
           artifactRunId: '${{ parameters.sourceBuildId }}'
+          architectures: ['amd64']
   - stage: containers_publish
     displayName: Publish Containers for ${{ parameters.releaseVersion }}
     dependsOn: 
       - release_artifacts
       - containers_publish_with_suffix
-    condition: and(succeeded(), startsWith(variables['build.sourceBranch'], 'refs/heads/release-'))
+    condition: and(in(dependencies.containers_publish_with_suffix.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'), startsWith(variables['build.sourceBranch'], 'refs/heads/release-'))
     jobs:
       - template: 'templates/jobs/push_container.yaml'
         parameters:
@@ -89,3 +90,4 @@ stages:
           artifactPipeline: '${{ parameters.sourcePipelineId }}'
           artifactRunVersion: 'specific'
           artifactRunId: '${{ parameters.sourceBuildId }}'
+          architectures: ['amd64']

--- a/.azure/scripts/container-push.sh
+++ b/.azure/scripts/container-push.sh
@@ -3,10 +3,18 @@ set -e
 
 echo "Build reason: ${BUILD_REASON}"
 echo "Source branch: ${BRANCH}"
+echo "Requested architectures ${ARCHITECTURES}"
 echo "Pushing container images for ${DOCKER_TAG}"
 
 # Tag and Push the container
 echo "Login into Docker Hub ..."
 docker login -u $DOCKER_USER -p $DOCKER_PASS $DOCKER_REGISTRY
 
-make docker_load docker_tag docker_push
+make docker_delete_manifest
+
+for ARCH in $ARCHITECTURES
+do
+    DOCKER_ARCHITECTURE=$ARCH make docker_load docker_tag docker_push docker_amend_manifest
+done
+
+make docker_push_manifest

--- a/.azure/scripts/java-build.sh
+++ b/.azure/scripts/java-build.sh
@@ -5,4 +5,4 @@ echo "Build reason: ${BUILD_REASON}"
 echo "Source branch: ${BRANCH}"
 
 # Build with Maven
-make java_package
+make java_verify

--- a/.azure/templates/jobs/build_container.yaml
+++ b/.azure/templates/jobs/build_container.yaml
@@ -1,11 +1,17 @@
 jobs:
   - job: 'build_container'
     displayName: 'Build'
+    # Strategy for the job
+    strategy:
+      matrix:
+        ${{ each arch in parameters.architectures }}:
+          ${{ arch }}:
+            arch: ${{ arch }}
     # Set timeout for jobs
     timeoutInMinutes: 60
     # Base system
     pool:
-      vmImage: 'Ubuntu-18.04'
+      vmImage: 'Ubuntu-20.04'
     # Pipeline steps
     steps:
       - template: '../steps/setup_docker.yaml'
@@ -22,10 +28,12 @@ jobs:
         displayName: "Untar the target directory"
       - bash: ".azure/scripts/container-build.sh"
         env:
+          DOCKER_BUILDKIT: 1
           BUILD_REASON: $(Build.Reason)
           BRANCH: $(Build.SourceBranch)
           DOCKER_REGISTRY: "quay.io"
           DOCKER_ORG: "strimzi"
-        displayName: "Build container"
-      - publish: $(System.DefaultWorkingDirectory)/drain-cleaner-container.tar.gz
-        artifact: Container
+          DOCKER_ARCHITECTURE: $(arch)
+        displayName: "Build container - $(arch)"
+      - publish: $(System.DefaultWorkingDirectory)/drain-cleaner-container-$(arch).tar.gz
+        artifact: Container-$(arch)

--- a/.azure/templates/jobs/build_java.yaml
+++ b/.azure/templates/jobs/build_java.yaml
@@ -1,0 +1,45 @@
+jobs:
+  - job: 'build_and_test_java'
+    displayName: 'Build & Test'
+    # Strategy for the job
+    strategy:
+      matrix:
+        'java-11':
+          image: 'Ubuntu-20.04'
+          jdk_version: '11'
+          jdk_path: '/usr/lib/jvm/java-11-openjdk-amd64'
+    # Set timeout for jobs
+    timeoutInMinutes: 60
+    # Base system
+    pool:
+      vmImage: $(image)
+    # Variables
+    variables:
+      MVN_CACHE_FOLDER: $(HOME)/.m2/repository
+      MVN_ARGS: '-e -V -B'
+    # Pipeline steps
+    steps:
+      # Get cached Maven repository
+      - template: "../steps/maven_cache.yaml"
+      - template: '../steps/setup_java.yaml'
+        parameters:
+          JDK_PATH: $(jdk_path)
+          JDK_VERSION: $(jdk_version)
+      - bash: ".azure/scripts/java-build.sh"
+        displayName: "Build & Test Java"
+        env:
+          BUILD_REASON: $(Build.Reason)
+          BRANCH: $(Build.SourceBranch)
+          MVN_ARGS: "-B -Dquarkus.native.container-build=true"
+      # We have to TAR the target directory to maintain the permissions of
+      # the files which would otherwise change when downloading the artifact
+      - bash: tar -cvpf target.tar ./target
+        displayName: "Tar the target directory"
+      - publish: $(System.DefaultWorkingDirectory)/target.tar
+        artifact: Binary
+      - task: PublishTestResults@2
+        inputs:
+          testResultsFormat: JUnit
+          testResultsFiles: '**/TEST-*.xml'
+          testRunTitle: "Unit & Integration tests"
+        condition: always()

--- a/.azure/templates/jobs/push_container.yaml
+++ b/.azure/templates/jobs/push_container.yaml
@@ -5,19 +5,20 @@ jobs:
     timeoutInMinutes: 60
     # Base system
     pool:
-      vmImage: 'Ubuntu-18.04'
+      vmImage: 'Ubuntu-20.04'
     # Pipeline steps
     steps:
       - template: '../steps/setup_docker.yaml'
-      - task: DownloadPipelineArtifact@2
-        inputs:
-          source: '${{ parameters.artifactSource }}'
-          artifact: Container
-          path: $(System.DefaultWorkingDirectory)
-          project: '${{ parameters.artifactProject }}'
-          pipeline: '${{ parameters.artifactPipeline }}'
-          runVersion: '${{ parameters.artifactRunVersion }}'
-          runId: '${{ parameters.artifactRunId }}'
+      - ${{ each arch in parameters.architectures }}:
+          - task: DownloadPipelineArtifact@2
+            inputs:
+              source: '${{ parameters.artifactSource }}'
+              artifact: Container-${{ arch }}
+              path: $(System.DefaultWorkingDirectory)
+              project: '${{ parameters.artifactProject }}'
+              pipeline: '${{ parameters.artifactPipeline }}'
+              runVersion: '${{ parameters.artifactRunVersion }}'
+              runId: '${{ parameters.artifactRunId }}'
       - bash: ".azure/scripts/container-push.sh"
         env:
           BUILD_REASON: $(Build.Reason)
@@ -27,4 +28,5 @@ jobs:
           DOCKER_REGISTRY: "quay.io"
           DOCKER_ORG: "strimzi"
           DOCKER_TAG: '${{ parameters.dockerTag }}'
+          ARCHITECTURES: ${{ join(' ', parameters.architectures) }}
         displayName: "Tag & Push container"

--- a/.azure/templates/jobs/run_systemtests.yaml
+++ b/.azure/templates/jobs/run_systemtests.yaml
@@ -3,10 +3,12 @@ jobs:
     displayName: "Run systemtests"
     strategy:
       matrix:
-        'java-11':
-          image: 'Ubuntu-18.04'
-          jdk_version: '11'
-          jdk_path: '/usr/lib/jvm/java-11-openjdk-amd64'
+        ${{ each arch in parameters.architectures }}:
+          ${{ arch }}:
+            arch: ${{ arch }}
+            image: 'Ubuntu-20.04'
+            jdk_version: '11'
+            jdk_path: '/usr/lib/jvm/java-11-openjdk-amd64'
     pool:
       vmImage: $(image)
     timeoutInMinutes: 20
@@ -20,14 +22,16 @@ jobs:
       - task: DownloadPipelineArtifact@2
         inputs:
           source: current
-          artifact: Container
+          artifact: Container-$(arch)
           path: $(System.DefaultWorkingDirectory)
       - bash: |
           eval $(minikube docker-env)
-          make docker_load
+          DOCKER_ARCHITECTURE=$(arch) make docker_load
           make docker_tag
           make docker_push
-        displayName: 'Docker load & tag & push to local registries'
+        env:
+          BUILD_TAG: latest-$(arch)
+        displayName: 'Docker load & tag & push to local registries - $(arch)'
       - script: |
           echo "##vso[task.setvariable variable=docker_registry]$(kubectl get service registry -n kube-system -o=jsonpath='{.spec.clusterIP}'):80"
         displayName: "Set docker_registry to local registry in minikube"
@@ -42,4 +46,4 @@ jobs:
           DOCKER_REGISTRY: registry.minikube
           DOCKER_ORG: strimzi
           DOCKER_TAG: latest
-        displayName: 'Run systemtests'
+        displayName: 'Run systemtests - $(arch)'

--- a/.azure/templates/steps/maven_cache.yaml
+++ b/.azure/templates/steps/maven_cache.yaml
@@ -1,0 +1,9 @@
+steps:
+  - task: Cache@2
+    inputs:
+      key: 'maven-cache | $(System.JobName) | **/pom.xml'
+      restoreKeys: |
+        maven-cache | $(System.JobName)
+        maven-cache
+      path: $(HOME)/.m2/repository
+    displayName: Maven cache

--- a/.azure/templates/steps/setup_docker.yaml
+++ b/.azure/templates/steps/setup_docker.yaml
@@ -1,7 +1,10 @@
 # Steps needed for local Docker installation
 steps:
-- task: DockerInstaller@0
-  displayName: Docker Installer
-  inputs:
-    dockerVersion: 20.10.8
-    releaseType: stable
+  - task: DockerInstaller@0
+    displayName: Docker Installer
+    inputs:
+      dockerVersion: 20.10.8
+      releaseType: stable
+  - bash: |
+      docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+    displayName: 'Register QEMU binary'

--- a/.azure/templates/steps/setup_java.yaml
+++ b/.azure/templates/steps/setup_java.yaml
@@ -1,5 +1,5 @@
 # Step to setup JAVA on the agent
-# We use openjdk-X, where X is Java version (8 or 11). Images are based on Java 8
+# We use openjdk-X, where X is Java version (8 or 11). Images are based on Java 11
 parameters:
   - name: JDK_PATH
     default: '/usr/lib/jvm/java-11-openjdk-amd64'

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -11,32 +11,52 @@ DOCKER_ORG         ?= $(USER)
 DOCKER_TAG         ?= latest
 BUILD_TAG          ?= latest
 
+ifdef DOCKER_ARCHITECTURE
+  DOCKER_PLATFORM = --platform linux/$(DOCKER_ARCHITECTURE)
+  DOCKER_PLATFORM_TAG_SUFFIX = -$(DOCKER_ARCHITECTURE)
+endif
+
 .PHONY: docker_build
 docker_build:
 	# Build Docker image ...
-	docker $(DOCKER_BUILDX) build $(DOCKER_BUILD_ARGS) -t strimzi/$(PROJECT_NAME):latest $(DOCKERFILE_DIR)
+	docker $(DOCKER_BUILDX) build $(DOCKER_PLATFORM) $(DOCKER_BUILD_ARGS) -t strimzi/$(PROJECT_NAME):latest $(DOCKERFILE_DIR)
 #   The Dockerfiles all use FROM ...:latest, so it is necessary to tag images with latest (-t above)
 #   But because we generate Kafka images for different versions we also need to tag with something
 #   including the kafka version number. This BUILD_TAG is used by the docker_tag target.
 	# Also tag with $(BUILD_TAG)
-	docker tag strimzi/$(PROJECT_NAME):latest strimzi/$(PROJECT_NAME):$(BUILD_TAG)
+	docker tag strimzi/$(PROJECT_NAME):latest strimzi/$(PROJECT_NAME):$(BUILD_TAG)$(DOCKER_PLATFORM_TAG_SUFFIX)
 
 .PHONY: docker_save
 docker_save:
 	# Saves the container as TGZ file
-	docker save strimzi/$(PROJECT_NAME):$(BUILD_TAG) | gzip > drain-cleaner-container.tar.gz
+	docker save strimzi/$(PROJECT_NAME):$(BUILD_TAG)$(DOCKER_PLATFORM_TAG_SUFFIX) | gzip > drain-cleaner-container$(DOCKER_PLATFORM_TAG_SUFFIX).tar.gz
 
 .PHONY: docker_load
 docker_load:
 	# Loads the container as TGZ file
-	docker load < drain-cleaner-container.tar.gz
+	docker load < drain-cleaner-container$(DOCKER_PLATFORM_TAG_SUFFIX).tar.gz
 
 .PHONY: docker_tag
 docker_tag:
 	# Tag the $(BUILD_TAG) image we built with the given $(DOCKER_TAG) tag
-	docker tag strimzi/$(PROJECT_NAME):$(BUILD_TAG) $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG)
+	docker tag strimzi/$(PROJECT_NAME):$(BUILD_TAG)$(DOCKER_PLATFORM_TAG_SUFFIX) $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG)$(DOCKER_PLATFORM_TAG_SUFFIX)
 
 .PHONY: docker_push
 docker_push: docker_tag
 	# Push the $(DOCKER_TAG)-tagged image to the registry
-	docker push $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG)
+	docker push $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG)$(DOCKER_PLATFORM_TAG_SUFFIX)
+
+.PHONY: docker_amend_manifest
+docker_amend_manifest:
+	# Create / Amend the manifest
+	docker manifest create $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG) --amend $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG)$(DOCKER_PLATFORM_TAG_SUFFIX)
+
+.PHONY: docker_push_manifest
+docker_push_manifest:
+	# Push the manifest to the registry
+	docker manifest push $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG)
+
+.PHONY: docker_delete_manifest
+docker_delete_manifest:
+	# Delete the manifest to the registry, ignore the error if manifest doesn't exist
+	docker manifest rm $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG) || true


### PR DESCRIPTION
This PR adds basic support for multiplatform builds to our Azure Pipelines. It keeps them running only for `amd64` for the time being. Before we enanle the builds also for other platforms, we need to remove the native build, modify the Dockerfile and the source code to be able to build for other platforms as well. But after this PR, the Azure pipelines should be ready and should produce the per-platform container image + manifest.