### PR TITLE
Update Quarkus to 2.12.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,10 +19,10 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     
     <!-- Quarkus -->
-    <quarkus-plugin.version>2.11.3.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.12.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.11.3.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.12.0.Final</quarkus.platform.version>
     
     <!-- Other versions -->
     <log4j.version>2.17.2</log4j.version>


### PR DESCRIPTION
This PR updates the Quarkus version to 2.12.0 to be up to date. Once update, we should target the next release.