### PR TITLE
Move to Java 17 and Quarkus 2.14

### DIFF
--- a/.azure/release-pipeline.yaml
+++ b/.azure/release-pipeline.yaml
@@ -34,10 +34,10 @@ stages:
         displayName: 'Release Artifacts'
         strategy:
           matrix:
-            'java-11':
+            'java-17':
               image: 'Ubuntu-20.04'
-              jdk_version: '11'
-              jdk_path: '/usr/lib/jvm/java-11-openjdk-amd64'
+              jdk_version: '17'
+              jdk_path: '/usr/lib/jvm/java-17-openjdk-amd64'
         # Set timeout for jobs
         timeoutInMinutes: 60
         # Base system

--- a/.azure/templates/jobs/build_java.yaml
+++ b/.azure/templates/jobs/build_java.yaml
@@ -4,10 +4,10 @@ jobs:
     # Strategy for the job
     strategy:
       matrix:
-        'java-11':
+        'java-17':
           image: 'Ubuntu-20.04'
-          jdk_version: '11'
-          jdk_path: '/usr/lib/jvm/java-11-openjdk-amd64'
+          jdk_version: '17'
+          jdk_path: '/usr/lib/jvm/java-17-openjdk-amd64'
     # Set timeout for jobs
     timeoutInMinutes: 60
     # Base system

--- a/.azure/templates/jobs/run_systemtests.yaml
+++ b/.azure/templates/jobs/run_systemtests.yaml
@@ -7,8 +7,8 @@ jobs:
           ${{ arch }}:
             arch: ${{ arch }}
             image: 'Ubuntu-20.04'
-            jdk_version: '11'
-            jdk_path: '/usr/lib/jvm/java-11-openjdk-amd64'
+            jdk_version: '17'
+            jdk_path: '/usr/lib/jvm/java-17-openjdk-amd64'
     pool:
       vmImage: $(image)
     timeoutInMinutes: 20

--- a/.azure/templates/steps/setup_java.yaml
+++ b/.azure/templates/steps/setup_java.yaml
@@ -1,10 +1,10 @@
-# Step to setup JAVA on the agent
-# We use openjdk-X, where X is Java version (8 or 11). Images are based on Java 11
+# Step to set up JAVA on the agent
+# We use openjdk-X, where X is Java version. Images are based on Java 17
 parameters:
   - name: JDK_PATH
-    default: '/usr/lib/jvm/java-11-openjdk-amd64'
+    default: '/usr/lib/jvm/java-17-openjdk-amd64'
   - name: JDK_VERSION
-    default: '11'
+    default: '17'
 steps:
 
 - bash: |
@@ -12,15 +12,15 @@ steps:
   displayName: 'Update package list'
 
 - bash: |
-    sudo apt-get install openjdk-11-jdk
-  displayName: 'Install openjdk11'
-  condition: eq(variables['JDK_VERSION'], '11')
+    sudo apt-get install openjdk-17-jdk
+  displayName: 'Install openjdk17'
+  condition: eq(variables['JDK_VERSION'], '17')
 
 - bash: |
-    echo "##vso[task.setvariable variable=JAVA_VERSION_BUILD]11"
-    echo "##vso[task.setvariable variable=JAVA_VERSION]11"
-  displayName: 'Setup JAVA_VERSION=11'
-  condition: eq(variables['JDK_VERSION'], '11')
+    echo "##vso[task.setvariable variable=JAVA_VERSION_BUILD]17"
+    echo "##vso[task.setvariable variable=JAVA_VERSION]17"
+  displayName: 'Setup JAVA_VERSION=17'
+  condition: eq(variables['JDK_VERSION'], '17')
 
 - bash: |
     echo "##vso[task.setvariable variable=JAVA_HOME]$(JDK_PATH)"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
-ARG JAVA_VERSION=11
+ARG JAVA_VERSION=17
 ARG TARGETPLATFORM
 
 USER root
@@ -9,7 +9,7 @@ RUN microdnf update \
     && microdnf clean all
 
 # Set JAVA_HOME env var
-ENV JAVA_HOME /usr/lib/jvm/jre-11
+ENV JAVA_HOME /usr/lib/jvm/jre-17
 
 # Add strimzi user with UID 1001
 # The user is in the group 0 to have access to the mounted volumes and storage

--- a/bin/drain_cleaner_run.sh
+++ b/bin/drain_cleaner_run.sh
@@ -2,9 +2,6 @@
 set -e
 set +x
 
-# Deny illegal access option is supported only on Java 9 and higher
-JAVA_OPTS="${JAVA_OPTS} --illegal-access=deny"
-
 # Exit when we run out of heap memory
 JAVA_OPTS="${JAVA_OPTS} -XX:+ExitOnOutOfMemoryError"
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,24 +7,24 @@
   <version>1.0.0-SNAPSHOT</version>
   <properties>
     <!-- Maven plugins -->
-    <compiler-plugin.version>3.8.1</compiler-plugin.version>
-    <maven.checkstyle.version>3.1.2</maven.checkstyle.version>
-    <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+    <compiler-plugin.version>3.10.1</compiler-plugin.version>
+    <maven.checkstyle.version>3.2.0</maven.checkstyle.version>
+    <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
 
     <!-- Project options -->
     <maven.compiler.parameters>true</maven.compiler.parameters>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     
     <!-- Quarkus -->
-    <quarkus-plugin.version>2.12.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.14.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.12.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.14.0.Final</quarkus.platform.version>
     
-    <!-- Other versions -->
+    <!-- Other versions - used in Test -->
     <log4j.version>2.17.2</log4j.version>
     <jayway-jsonpath.version>2.6.0</jayway-jsonpath.version>
     <bouncycastle.version>1.68</bouncycastle.version>

--- a/src/main/java/io/strimzi/ValidatingWebhook.java
+++ b/src/main/java/io/strimzi/ValidatingWebhook.java
@@ -54,13 +54,11 @@ public class ValidatingWebhook {
     }
 
     private ObjectMeta extractEvictionMetadata(AdmissionRequest request)    {
-        if (request.getObject() instanceof Eviction) {
+        if (request.getObject() instanceof Eviction eviction) {
             LOG.debug("Received Eviction request of version v1");
-            Eviction eviction = (Eviction) request.getObject();
             return eviction.getMetadata();
-        } else if (request.getObject() instanceof io.fabric8.kubernetes.api.model.policy.v1beta1.Eviction) {
+        } else if (request.getObject() instanceof io.fabric8.kubernetes.api.model.policy.v1beta1.Eviction eviction) {
             LOG.debug("Received Eviction request of version v1beta1");
-            io.fabric8.kubernetes.api.model.policy.v1beta1.Eviction eviction = (io.fabric8.kubernetes.api.model.policy.v1beta1.Eviction) request.getObject();
             return eviction.getMetadata();
         } else {
             return null;

--- a/src/test/java/io/strimzi/test/ValidatingWebhookTest.java
+++ b/src/test/java/io/strimzi/test/ValidatingWebhookTest.java
@@ -36,9 +36,9 @@ import static org.mockito.Mockito.when;
 
 public class ValidatingWebhookTest {
     KubernetesClient client;
-    MixedOperation<Pod, PodList, PodResource<Pod>> pods;
-    NonNamespaceOperation<Pod, PodList, PodResource<Pod>> inNamespace;
-    PodResource<Pod> podResource;
+    MixedOperation<Pod, PodList, PodResource> pods;
+    NonNamespaceOperation<Pod, PodList, PodResource> inNamespace;
+    PodResource podResource;
 
     @SuppressWarnings("unchecked")
     @BeforeEach

--- a/src/test/java/io/strimzi/utils/StUtils.java
+++ b/src/test/java/io/strimzi/utils/StUtils.java
@@ -13,7 +13,7 @@ import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.api.model.policy.v1.PodDisruptionBudget;
-import io.fabric8.kubernetes.client.internal.readiness.Readiness;
+import io.fabric8.kubernetes.client.readiness.Readiness;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 import io.strimzi.utils.k8s.exception.WaitException;
@@ -134,7 +134,7 @@ public final class StUtils {
         int replicas = statefulSet.getSpec().getReplicas();
 
         LOGGER.info("Creating StatefulSet: {} in namespace: {}", stsName, namespaceName);
-        kubeClient().getClient().apps().statefulSets().inNamespace(namespaceName).create(statefulSet);
+        kubeClient().getClient().apps().statefulSets().inNamespace(namespaceName).resource(statefulSet).create();
 
         LOGGER.info("Waiting for StatefulSet to be ready");
         waitFor("StatefulSet to be created and ready", GLOBAL_POLL_INTERVAL, GLOBAL_TIMEOUT,
@@ -150,7 +150,7 @@ public final class StUtils {
         String pdbName = podDisruptionBudget.getMetadata().getName();
 
         LOGGER.info("Creating PodDisruptionBudget: {} in namespace: {}", pdbName, namespaceName);
-        kubeClient().getClient().policy().v1().podDisruptionBudget().inNamespace(namespaceName).create(podDisruptionBudget);
+        kubeClient().getClient().policy().v1().podDisruptionBudget().inNamespace(namespaceName).resource(podDisruptionBudget).create();
 
         LOGGER.info("Waiting for PodDisruptionBudget to be ready");
         waitFor("PodDisruptionBudget to be created and ready", GLOBAL_POLL_INTERVAL, GLOBAL_TIMEOUT,

--- a/src/test/java/io/strimzi/utils/k8s/KubeClient.java
+++ b/src/test/java/io/strimzi/utils/k8s/KubeClient.java
@@ -118,7 +118,7 @@ public class KubeClient {
     // ================================
 
     public Deployment createOrReplaceDeployment(Deployment deployment) {
-        return client.apps().deployments().inNamespace(deployment.getMetadata().getNamespace()).createOrReplace(deployment);
+        return client.apps().deployments().inNamespace(deployment.getMetadata().getNamespace()).resource(deployment).createOrReplace();
     }
 
     /**

--- a/src/test/java/io/strimzi/utils/k8s/cluster/KubeCluster.java
+++ b/src/test/java/io/strimzi/utils/k8s/cluster/KubeCluster.java
@@ -5,7 +5,7 @@
 package io.strimzi.utils.k8s.cluster;
 
 import io.fabric8.kubernetes.client.Config;
-import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.strimzi.utils.k8s.KubeClient;
 import io.strimzi.utils.k8s.exception.NoClusterException;
 import io.strimzi.utils.k8s.cmdClient.KubeCmdClient;
@@ -29,7 +29,7 @@ public interface KubeCluster {
     KubeCmdClient defaultCmdClient();
 
     default KubeClient defaultClient() {
-        return new KubeClient(new DefaultKubernetesClient(), "default");
+        return new KubeClient(new KubernetesClientBuilder().build(), "default");
     }
 
     /**

--- a/src/test/java/io/strimzi/utils/k8s/cluster/Kubernetes.java
+++ b/src/test/java/io/strimzi/utils/k8s/cluster/Kubernetes.java
@@ -4,9 +4,7 @@
  */
 package io.strimzi.utils.k8s.cluster;
 
-import io.fabric8.kubernetes.client.DefaultKubernetesClient;
-import io.fabric8.kubernetes.client.http.HttpClient;
-import io.fabric8.kubernetes.client.utils.HttpClientUtils;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.strimzi.utils.executor.Exec;
 import io.strimzi.utils.k8s.KubeClient;
 import io.strimzi.utils.k8s.cmdClient.KubeCmdClient;
@@ -17,7 +15,6 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 /**
  * A {@link KubeCluster} implementation for any {@code Kubernetes} cluster.
@@ -51,16 +48,7 @@ public class Kubernetes implements KubeCluster {
 
     @Override
     public KubeClient defaultClient() {
-        HttpClient httpClient = HttpClientUtils.createHttpClient(CONFIG);
-
-        httpClient = httpClient.newBuilder()
-            .preferHttp11()
-            .connectTimeout(60L, TimeUnit.SECONDS)
-            .writeTimeout(60L, TimeUnit.SECONDS)
-            .readTimeout(60L, TimeUnit.SECONDS)
-            .build();
-
-        return new KubeClient(new DefaultKubernetesClient(httpClient, CONFIG), "default");
+        return new KubeClient(new KubernetesClientBuilder().build(), "default");
     }
 
     public String toString() {


### PR DESCRIPTION
This PR updates the Drain Cleaner to use Java 17. It also updates Quarkus to 2.14 and fixes several deprecations warnings cause by a newer Fabric8 version puller by Quarkus.