### PR TITLE
Watch for changes to the TLS certificates

### DIFF
--- a/src/main/java/io/strimzi/CertificateWatch.java
+++ b/src/main/java/io/strimzi/CertificateWatch.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi;
+
+import io.quarkus.runtime.Quarkus;
+import io.quarkus.runtime.ShutdownEvent;
+import io.quarkus.runtime.StartupEvent;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Paths;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+
+/**
+ * Quarkus loads the TLS certificate at startup but does not reload it when it changes. So if the Drain Cleaner runs for
+ * too long, it can happen that the certificate expires and Kubernetes cannot call the webhook. To prevent this, the
+ * CertificateWatch is watching for changes to the TLS certificate files. If any changes are detected, it exits quarkus
+ * to restart the container. This is by default enabled for production with the default path {@code /etc/webhook-certificates/}
+ * (which is also the default path in the deployment). It is by default disabled in development. The configuration
+ * options {@code certificate.watch.enabled} and {@code certificate.watch.path} can be used to customize the default
+ * settings.
+ */
+@ApplicationScoped
+public class CertificateWatch {
+    private static final Logger LOG = LoggerFactory.getLogger(CertificateWatch.class);
+
+    private final boolean enabled;
+
+    private ChangeWatcher watcher;
+
+    /**
+     * Constructs the certificate watch. The Watcher class is created only if the certificate watch is enabled.
+     */
+    public CertificateWatch() {
+        this.enabled = ConfigProvider.getConfig().getOptionalValue("certificate.watch.enabled", Boolean.class).orElse(false);
+
+        if (enabled) {
+            try {
+                String path = ConfigProvider.getConfig().getOptionalValue("certificate.watch.path", String.class).orElse("/etc/webhook-certificates/");
+
+                LOG.error("Creating certificate watch for path {}", path);
+
+                this.watcher = new ChangeWatcher(path, () -> {
+                    LOG.info("Certificate change detected => Drain Cleaner will be restarted");
+                    Quarkus.asyncExit(0);
+                });
+            } catch (IOException e) {
+                LOG.error("Failed to create certificate watch", e);
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    /**
+     * Starts the watcher (if enabled)
+     *
+     * @param ev    Startup event
+     */
+    void onStart(@Observes StartupEvent ev) {
+        if (enabled) {
+            LOG.info("Starting certificate watch");
+            watcher.start();
+        } else {
+            LOG.info("Certificate watch is not enabled");
+        }
+    }
+
+    /**
+     * Stops the watcher (if enabled)
+     *
+     * @param ev    Shutdown event
+     */
+    void onStop(@Observes ShutdownEvent ev) {
+        if (enabled) {
+            LOG.info("Stopping certificate watch");
+            try {
+                watcher.stop();
+            } catch (InterruptedException e) {
+                LOG.warn("Failed to stop the certificate watcher", e);
+            }
+        }
+    }
+
+    /**
+     * Internal class which does the watching of a directory for changes using the Java NIO Watch service. If any change
+     * is detected, a handler is called to take the action.
+     */
+    public static class ChangeWatcher implements Runnable {
+        private final WatchService watchService;
+        private final Thread watcherThread;
+        private final Runnable changeHandler;
+
+        private volatile boolean stop = false;
+
+        /**
+         * Constructs the ChangeWatcher to watch for changes to a directory on the filesystem
+         *
+         * @param path      The directory which should be watched
+         * @param handler   The handler which should be run when any change is detected. The handler allows us to plug-in
+         *                  a custom behavior to react for the file change.
+         *
+         * @throws IOException  IOException is thrown if we fail to create the Watch service
+         */
+        public ChangeWatcher(String path, Runnable handler) throws IOException {
+            LOG.info("Creating ChangeWatcher for path {}", path);
+            this.watchService = FileSystems.getDefault().newWatchService();
+            this.watcherThread = new Thread(this, "certificate-change-watch");
+            this.changeHandler = handler;
+            Paths.get(path).register(watchService, StandardWatchEventKinds.ENTRY_CREATE, StandardWatchEventKinds.ENTRY_MODIFY, StandardWatchEventKinds.ENTRY_DELETE);
+        }
+
+        /**
+         * Starts watching
+         */
+        public void start() {
+            LOG.info("Starting the certificate watcher");
+            watcherThread.start();
+        }
+
+        @Override
+        public void run() {
+            while (!stop)   {
+                try {
+                    WatchKey key = watchService.take();
+
+                    if (key != null) {
+                        for (WatchEvent<?> event : key.pollEvents()) {
+                            LOG.warn("Certificate {} changed ({})", event.context(), event.kind().name());
+                            changeHandler.run();
+                        }
+                        key.reset();
+                    }
+                } catch (InterruptedException e) {
+                    LOG.debug("Certificate watch was interrupted", e);
+                }
+            }
+        }
+
+        /**
+         * Stops watching
+         *
+         * @throws InterruptedException Thrown if interrupted while trying to stop the watcher thread
+         */
+        public void stop() throws InterruptedException {
+            LOG.info("Requesting the certificate watcher to stop");
+            this.stop = true;
+
+            watcherThread.interrupt();
+            watcherThread.join();
+
+            try {
+                watchService.close();
+            } catch (IOException e) {
+                LOG.warn("Failed to stop the Java watch service", e);
+            }
+        }
+    }
+}

--- a/src/main/java/io/strimzi/CertificateWatch.java
+++ b/src/main/java/io/strimzi/CertificateWatch.java
@@ -48,7 +48,7 @@ public class CertificateWatch {
             try {
                 String path = ConfigProvider.getConfig().getOptionalValue("certificate.watch.path", String.class).orElse("/etc/webhook-certificates/");
 
-                LOG.error("Creating certificate watch for path {}", path);
+                LOG.info("Creating certificate watch for path {}", path);
 
                 this.watcher = new ChangeWatcher(path, () -> {
                     LOG.info("Certificate change detected => Drain Cleaner will be restarted");

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,6 +10,10 @@ quarkus.http.port=8080
 %prod.quarkus.http.ssl.certificate.files=/etc/webhook-certificates/tls.crt
 %prod.quarkus.http.ssl.certificate.key-files=/etc/webhook-certificates/tls.key
 
+# Certificate watch -> Production only
+%prod.certificate.watch.enabled=true
+%prod.certificate.watch.path=/etc/webhook-certificates/
+
 # Logging
 quarkus.log.level=INFO
 #quarkus.log.category.okhttp3.level=WARN

--- a/src/test/java/io/strimzi/CertificateWatchTest.java
+++ b/src/test/java/io/strimzi/CertificateWatchTest.java
@@ -2,9 +2,8 @@
  * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-package io.strimzi.test;
+package io.strimzi;
 
-import io.strimzi.CertificateWatch;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;

--- a/src/test/java/io/strimzi/HealthCheckTest.java
+++ b/src/test/java/io/strimzi/HealthCheckTest.java
@@ -2,9 +2,8 @@
  * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-package io.strimzi.test;
+package io.strimzi;
 
-import io.strimzi.HealthCheck;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/io/strimzi/ValidatingWebhookTest.java
+++ b/src/test/java/io/strimzi/ValidatingWebhookTest.java
@@ -2,7 +2,7 @@
  * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-package io.strimzi.test;
+package io.strimzi;
 
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
@@ -15,7 +15,6 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.PodResource;
-import io.strimzi.ValidatingWebhook;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;

--- a/src/test/java/io/strimzi/test/CertificateWatchTest.java
+++ b/src/test/java/io/strimzi/test/CertificateWatchTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.test;
+
+import io.strimzi.CertificateWatch;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class CertificateWatchTest {
+    @Test
+    public void testChangeDetection() throws IOException, InterruptedException {
+        Path tempDirectory = Files.createTempDirectory("watcher-test-dir");
+
+        // We use Atomic Reference to be able to reset the CountDownLatch while calking it from Lambda
+        AtomicReference<CountDownLatch> latch = new AtomicReference<>();
+        latch.set(new CountDownLatch(1));
+
+        CertificateWatch.ChangeWatcher watcher = new CertificateWatch.ChangeWatcher(tempDirectory.toFile().getAbsolutePath(), () -> latch.get().countDown());
+        watcher.start();
+
+        try {
+            Path testFile = Files.createTempFile(tempDirectory, "test", "file");
+
+            // Check creation
+            latch.get().await();
+            latch.set(new CountDownLatch(1));
+
+            // Check modification
+            Files.write(testFile, "Hello world".getBytes());
+            latch.get().await();
+            latch.set(new CountDownLatch(1));
+
+            // Check deletion
+            Files.deleteIfExists(testFile);
+            latch.get().await();
+        } finally {
+            watcher.stop();
+            Files.deleteIfExists(tempDirectory);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a watcher to watch for any changes to the TLS certificate files. If any change is detected, Drain Cleaner will exit to reload the certificate since Quarkus does not reload it.

This approach has some advantages such as not requiring any additional RBAC rights to watch the certificate secret and deleting itself. The main disadvantage is that exiting Drain Cleaner does not delete the Pod. It just restarts the container. So if the certificate by any chance changes too often, it will basically be crash-looping and have a back-off (However, the general expectation is to have the certificate renew ever few months and not every few minutes - so this should not be a major issue). Also if you come to it after few months, you might see restart events related to the certificate renewal which might be confusing.