### PR TITLE
Watch for changes to the TLS certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,25 @@ Follow the instructions in the `./install/kubernetes` directory to generate and 
 On Kubernetes, you can also use Helm to install Strimzi Drain Cleaner using our Helm Chart.
 The Helm Chart can be used to install it both with Cert Manager support as well as with your own certificates.
 
+### Certificate renewals
+
+By default, the Drain Cleaner deployment is watching the Kubernetes secret with TLS certificates for changes such as certificate renewals.
+If it detects such change, it will restart itself to reload the TLS certificate.
+The Drain Cleaner installation files enable this by default.
+But you can disable this by setting the `STRIMZI_CERTIFICATE_WATCH_ENABLED` environment variable to `false`.
+
+When enabled, can also use the following environment variables to configure the detailed behavior:
+
+| Environment Variable                     | Description                                                             | Default                 |
+|------------------------------------------|-------------------------------------------------------------------------|-------------------------|
+| `STRIMZI_CERTIFICATE_WATCH_ENABLED`      | Enables or disables the certificate watch                               | false                   |
+| `STRIMZI_CERTIFICATE_WATCH_NAMESPACE`    | The namespace where the Drain Cleaner is deployed                       | `strimzi-drain-cleaner` |
+| `STRIMZI_CERTIFICATE_WATCH_POD_NAME`     | The Drain Cleaner Pod name                                              |                         |
+| `STRIMZI_CERTIFICATE_WATCH_SECRET_NAME`  | The name of the secret with TLS certificates                            | `strimzi-drain-cleaner` |
+| `STRIMZI_CERTIFICATE_WATCH_SECRET_KEYS`  | The list of fields inside the secret which contain the TLS certificates | `tls.crt,tls.key`       |
+
+The best way to configure `STRIMZI_CERTIFICATE_WATCH_NAMESPACE` and `STRIMZI_CERTIFICATE_WATCH_POD_NAME` is using the [Kubernetes Downward API](https://kubernetes.io/docs/concepts/workloads/pods/downward-api/).
+
 ## See it in action
 
 You can easily test how it works:

--- a/README.md
+++ b/README.md
@@ -112,13 +112,13 @@ But you can disable this by setting the `STRIMZI_CERTIFICATE_WATCH_ENABLED` envi
 
 When enabled, can also use the following environment variables to configure the detailed behavior:
 
-| Environment Variable                     | Description                                                             | Default                 |
-|------------------------------------------|-------------------------------------------------------------------------|-------------------------|
-| `STRIMZI_CERTIFICATE_WATCH_ENABLED`      | Enables or disables the certificate watch                               | false                   |
-| `STRIMZI_CERTIFICATE_WATCH_NAMESPACE`    | The namespace where the Drain Cleaner is deployed                       | `strimzi-drain-cleaner` |
-| `STRIMZI_CERTIFICATE_WATCH_POD_NAME`     | The Drain Cleaner Pod name                                              |                         |
-| `STRIMZI_CERTIFICATE_WATCH_SECRET_NAME`  | The name of the secret with TLS certificates                            | `strimzi-drain-cleaner` |
-| `STRIMZI_CERTIFICATE_WATCH_SECRET_KEYS`  | The list of fields inside the secret which contain the TLS certificates | `tls.crt,tls.key`       |
+| Environment Variable                     | Description                                                                               | Default                 |
+|------------------------------------------|-------------------------------------------------------------------------------------------|-------------------------|
+| `STRIMZI_CERTIFICATE_WATCH_ENABLED`      | Enables or disables the certificate watch                                                 | false                   |
+| `STRIMZI_CERTIFICATE_WATCH_NAMESPACE`    | The namespace where the Drain Cleaner is deployed and where the certificate secret exists | `strimzi-drain-cleaner` |
+| `STRIMZI_CERTIFICATE_WATCH_POD_NAME`     | The Drain Cleaner Pod name                                                                |                         |
+| `STRIMZI_CERTIFICATE_WATCH_SECRET_NAME`  | The name of the secret with TLS certificates                                              | `strimzi-drain-cleaner` |
+| `STRIMZI_CERTIFICATE_WATCH_SECRET_KEYS`  | The list of fields inside the secret which contain the TLS certificates                   | `tls.crt,tls.key`       |
 
 The best way to configure `STRIMZI_CERTIFICATE_WATCH_NAMESPACE` and `STRIMZI_CERTIFICATE_WATCH_POD_NAME` is using the [Kubernetes Downward API](https://kubernetes.io/docs/concepts/workloads/pods/downward-api/).
 

--- a/packaging/helm-charts/helm3/strimzi-drain-cleaner/templates/020-ClusterRole.yaml
+++ b/packaging/helm-charts/helm3/strimzi-drain-cleaner/templates/020-ClusterRole.yaml
@@ -6,6 +6,8 @@ metadata:
   labels:
     {{- include "strimzi-drain-cleaner.labels" . | nindent 4 }}
 rules:
+  # Drain Cleaner needs to be able to get the Kafka or ZooKeeper pods that are being evicted and patch them with the
+  # annotation which tells Strimzi Cluster Operator to roll the Pod
   - apiGroups:
       - ""
     resources:

--- a/packaging/helm-charts/helm3/strimzi-drain-cleaner/templates/021-Role.yaml
+++ b/packaging/helm-charts/helm3/strimzi-drain-cleaner/templates/021-Role.yaml
@@ -7,12 +7,17 @@ metadata:
     {{- include "strimzi-drain-cleaner.labels" . | nindent 4 }}
   namespace: {{default .Release.Namespace .Values.namespace.name }}
 rules:
+  # When certificate reloading is enabled, Drain Cleaner will delete itself to reload the certificates. Therefore it
+  # needs the right to delete the pods in its own namespace.
   - apiGroups:
       - ""
     resources:
       - pods
     verbs:
       - delete
+  # When certificate reloading is enabled, Strimzi needs to be able to get, list and watch the Secret with the
+  # certificate to detect any changes to it. The RBAC allows it to watch only one Secret with given name. If your
+  # certificate Secret has a custom name, you need to modify this Role accordingly.
   - apiGroups:
       - ""
     resources:

--- a/packaging/helm-charts/helm3/strimzi-drain-cleaner/templates/021-Role.yaml
+++ b/packaging/helm-charts/helm3/strimzi-drain-cleaner/templates/021-Role.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "strimzi-drain-cleaner.serviceAccountName" . }}
+  labels:
+    {{- include "strimzi-drain-cleaner.labels" . | nindent 4 }}
+  namespace: {{default .Release.Namespace .Values.namespace.name }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - watch
+      - list
+    resourceNames:
+      - strimzi-drain-cleaner
+{{- end }}

--- a/packaging/helm-charts/helm3/strimzi-drain-cleaner/templates/031-RoleBinding.yaml
+++ b/packaging/helm-charts/helm3/strimzi-drain-cleaner/templates/031-RoleBinding.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "strimzi-drain-cleaner.serviceAccountName" . }}
+  labels:
+    {{- include "strimzi-drain-cleaner.labels" . | nindent 4 }}
+  namespace: {{default .Release.Namespace .Values.namespace.name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "strimzi-drain-cleaner.serviceAccountName" . }}
+    namespace: {{default .Release.Namespace .Values.namespace.name }}
+roleRef:
+  kind: Role
+  name: {{ include "strimzi-drain-cleaner.serviceAccountName" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/packaging/helm-charts/helm3/strimzi-drain-cleaner/values.yaml
+++ b/packaging/helm-charts/helm3/strimzi-drain-cleaner/values.yaml
@@ -63,3 +63,13 @@ env:
     value: "true"
   - name: STRIMZI_DRAIN_ZOOKEEPER
     value: "true"
+  - name: STRIMZI_CERTIFICATE_WATCH_ENABLED
+    value: "true"
+  - name: STRIMZI_CERTIFICATE_WATCH_NAMESPACE
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.namespace
+  - name: STRIMZI_CERTIFICATE_WATCH_POD_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.name

--- a/packaging/install/certmanager/020-ClusterRole.yaml
+++ b/packaging/install/certmanager/020-ClusterRole.yaml
@@ -5,6 +5,8 @@ metadata:
   labels:
     app: strimzi-drain-cleaner
 rules:
+  # Drain Cleaner needs to be able to get the Kafka or ZooKeeper pods that are being evicted and patch them with the
+  # annotation which tells Strimzi Cluster Operator to roll the Pod
   - apiGroups:
       - ""
     resources:

--- a/packaging/install/certmanager/021-Role.yaml
+++ b/packaging/install/certmanager/021-Role.yaml
@@ -6,12 +6,17 @@ metadata:
     app: strimzi-drain-cleaner
   namespace: strimzi-drain-cleaner
 rules:
+  # When certificate reloading is enabled, Drain Cleaner will delete itself to reload the certificates. Therefore it
+  # needs the right to delete the pods in its own namespace.
   - apiGroups:
       - ""
     resources:
       - pods
     verbs:
       - delete
+  # When certificate reloading is enabled, Strimzi needs to be able to get, list and watch the Secret with the
+  # certificate to detect any changes to it. The RBAC allows it to watch only one Secret with given name. If your
+  # certificate Secret has a custom name, you need to modify this Role accordingly.
   - apiGroups:
       - ""
     resources:

--- a/packaging/install/certmanager/021-Role.yaml
+++ b/packaging/install/certmanager/021-Role.yaml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: strimzi-drain-cleaner
+  labels:
+    app: strimzi-drain-cleaner
+  namespace: strimzi-drain-cleaner
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - watch
+      - list
+    resourceNames:
+      - strimzi-drain-cleaner

--- a/packaging/install/certmanager/031-RoleBinding.yaml
+++ b/packaging/install/certmanager/031-RoleBinding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: strimzi-drain-cleaner
+  labels:
+    app: strimzi-drain-cleaner
+  namespace: strimzi-drain-cleaner
+subjects:
+  - kind: ServiceAccount
+    name: strimzi-drain-cleaner
+    namespace: strimzi-drain-cleaner
+roleRef:
+  kind: Role
+  name: strimzi-drain-cleaner
+  apiGroup: rbac.authorization.k8s.io

--- a/packaging/install/certmanager/060-Deployment.yaml
+++ b/packaging/install/certmanager/060-Deployment.yaml
@@ -29,6 +29,16 @@ spec:
               value: "true"
             - name: STRIMZI_DRAIN_ZOOKEEPER
               value: "true"
+            - name: STRIMZI_CERTIFICATE_WATCH_ENABLED
+              value: "true"
+            - name: STRIMZI_CERTIFICATE_WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: STRIMZI_CERTIFICATE_WATCH_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           args:
             - /opt/strimzi/bin/drain_cleaner_run.sh
           volumeMounts:

--- a/packaging/install/kubernetes/020-ClusterRole.yaml
+++ b/packaging/install/kubernetes/020-ClusterRole.yaml
@@ -5,6 +5,8 @@ metadata:
   labels:
     app: strimzi-drain-cleaner
 rules:
+  # Drain Cleaner needs to be able to get the Kafka or ZooKeeper pods that are being evicted and patch them with the
+  # annotation which tells Strimzi Cluster Operator to roll the Pod
   - apiGroups:
       - ""
     resources:

--- a/packaging/install/kubernetes/021-Role.yaml
+++ b/packaging/install/kubernetes/021-Role.yaml
@@ -6,12 +6,17 @@ metadata:
     app: strimzi-drain-cleaner
   namespace: strimzi-drain-cleaner
 rules:
+  # When certificate reloading is enabled, Drain Cleaner will delete itself to reload the certificates. Therefore it
+  # needs the right to delete the pods in its own namespace.
   - apiGroups:
       - ""
     resources:
       - pods
     verbs:
       - delete
+  # When certificate reloading is enabled, Strimzi needs to be able to get, list and watch the Secret with the
+  # certificate to detect any changes to it. The RBAC allows it to watch only one Secret with given name. If your
+  # certificate Secret has a custom name, you need to modify this Role accordingly.
   - apiGroups:
       - ""
     resources:

--- a/packaging/install/kubernetes/021-Role.yaml
+++ b/packaging/install/kubernetes/021-Role.yaml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: strimzi-drain-cleaner
+  labels:
+    app: strimzi-drain-cleaner
+  namespace: strimzi-drain-cleaner
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - watch
+      - list
+    resourceNames:
+      - strimzi-drain-cleaner

--- a/packaging/install/kubernetes/031-RoleBinding.yaml
+++ b/packaging/install/kubernetes/031-RoleBinding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: strimzi-drain-cleaner
+  labels:
+    app: strimzi-drain-cleaner
+  namespace: strimzi-drain-cleaner
+subjects:
+  - kind: ServiceAccount
+    name: strimzi-drain-cleaner
+    namespace: strimzi-drain-cleaner
+roleRef:
+  kind: Role
+  name: strimzi-drain-cleaner
+  apiGroup: rbac.authorization.k8s.io

--- a/packaging/install/kubernetes/060-Deployment.yaml
+++ b/packaging/install/kubernetes/060-Deployment.yaml
@@ -29,6 +29,16 @@ spec:
               value: "true"
             - name: STRIMZI_DRAIN_ZOOKEEPER
               value: "true"
+            - name: STRIMZI_CERTIFICATE_WATCH_ENABLED
+              value: "true"
+            - name: STRIMZI_CERTIFICATE_WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: STRIMZI_CERTIFICATE_WATCH_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           args:
             - /opt/strimzi/bin/drain_cleaner_run.sh
           volumeMounts:

--- a/packaging/install/openshift/020-ClusterRole.yaml
+++ b/packaging/install/openshift/020-ClusterRole.yaml
@@ -5,6 +5,8 @@ metadata:
   labels:
     app: strimzi-drain-cleaner
 rules:
+  # Drain Cleaner needs to be able to get the Kafka or ZooKeeper pods that are being evicted and patch them with the
+  # annotation which tells Strimzi Cluster Operator to roll the Pod
   - apiGroups:
       - ""
     resources:

--- a/packaging/install/openshift/021-Role.yaml
+++ b/packaging/install/openshift/021-Role.yaml
@@ -6,12 +6,17 @@ metadata:
     app: strimzi-drain-cleaner
   namespace: strimzi-drain-cleaner
 rules:
+  # When certificate reloading is enabled, Drain Cleaner will delete itself to reload the certificates. Therefore it
+  # needs the right to delete the pods in its own namespace.
   - apiGroups:
       - ""
     resources:
       - pods
     verbs:
       - delete
+  # When certificate reloading is enabled, Strimzi needs to be able to get, list and watch the Secret with the
+  # certificate to detect any changes to it. The RBAC allows it to watch only one Secret with given name. If your
+  # certificate Secret has a custom name, you need to modify this Role accordingly.
   - apiGroups:
       - ""
     resources:

--- a/packaging/install/openshift/021-Role.yaml
+++ b/packaging/install/openshift/021-Role.yaml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: strimzi-drain-cleaner
+  labels:
+    app: strimzi-drain-cleaner
+  namespace: strimzi-drain-cleaner
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - watch
+      - list
+    resourceNames:
+      - strimzi-drain-cleaner

--- a/packaging/install/openshift/031-RoleBinding.yaml
+++ b/packaging/install/openshift/031-RoleBinding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: strimzi-drain-cleaner
+  labels:
+    app: strimzi-drain-cleaner
+  namespace: strimzi-drain-cleaner
+subjects:
+  - kind: ServiceAccount
+    name: strimzi-drain-cleaner
+    namespace: strimzi-drain-cleaner
+roleRef:
+  kind: Role
+  name: strimzi-drain-cleaner
+  apiGroup: rbac.authorization.k8s.io

--- a/packaging/install/openshift/060-Deployment.yaml
+++ b/packaging/install/openshift/060-Deployment.yaml
@@ -29,6 +29,16 @@ spec:
               value: "true"
             - name: STRIMZI_DRAIN_ZOOKEEPER
               value: "true"
+            - name: STRIMZI_CERTIFICATE_WATCH_ENABLED
+              value: "true"
+            - name: STRIMZI_CERTIFICATE_WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: STRIMZI_CERTIFICATE_WATCH_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           args:
             - /opt/strimzi/bin/drain_cleaner_run.sh
           volumeMounts:

--- a/pom.xml
+++ b/pom.xml
@@ -19,10 +19,10 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     
     <!-- Quarkus -->
-    <quarkus-plugin.version>2.14.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.15.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.14.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.15.2.Final</quarkus.platform.version>
     
     <!-- Other versions - used in Test -->
     <log4j.version>2.17.2</log4j.version>

--- a/src/main/java/io/strimzi/CertificateWatch.java
+++ b/src/main/java/io/strimzi/CertificateWatch.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi;
+
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.informers.ResourceEventHandler;
+import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
+import io.quarkus.runtime.ShutdownEvent;
+import io.quarkus.runtime.StartupEvent;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Quarkus loads the TLS certificate at startup but does not reload it when it changes. So if the Drain Cleaner runs for
+ * too long, it can happen that the certificate expires and Kubernetes cannot call the webhook. To prevent this, the
+ * CertificateWatch is watching for changes to the Kubernetes Secret with the TLS certificates. If any changes are
+ * detected, it will delete itself through the Kubernetes API (delete the Pod it runs in). It is by default disabled
+ * in development. The configuration options {@code strimzi.certificate.watch.enabled} and
+ * {@code strimzi.certificate.watch.*} options can be used to customize the default settings.
+ */
+@ApplicationScoped
+public class CertificateWatch {
+    private static final Logger LOG = LoggerFactory.getLogger(CertificateWatch.class);
+
+    @Inject
+    KubernetesClient client;
+
+    private final boolean enabled;
+    private final String namespace;
+    private final String podName;
+    private final String secretName;
+    private final List<String> secretKeys;
+
+    private SharedIndexInformer<Secret> secretInformer;
+    /* test */ String previousValues;
+
+    /**
+     * Constructs the certificate watch. If watching for the certificate changes is enabled, it will also validate the
+     * configuration. This is the default constructor used in production which gets the values from quarkus configuration.
+     */
+    @SuppressWarnings("unused")
+    public CertificateWatch() {
+        this(ConfigProvider.getConfig().getOptionalValue("strimzi.certificate.watch.enabled", Boolean.class).orElse(false),
+                ConfigProvider.getConfig().getOptionalValue("strimzi.certificate.watch.namespace", String.class).orElse(null),
+                ConfigProvider.getConfig().getOptionalValue("strimzi.certificate.watch.pod.name", String.class).orElse(null),
+                ConfigProvider.getConfig().getOptionalValue("strimzi.certificate.watch.secret.name", String.class).orElse(null),
+                ConfigProvider.getConfig().getOptionalValues("strimzi.certificate.watch.secret.keys", String.class).orElse(null));
+    }
+
+    /**
+     * Constructor used by tests to pass mocked values
+     *
+     * @param client        Kubernetes client
+     * @param enabled       Enables / disables the certificate watch
+     * @param namespace     Drain Cleaner namespace
+     * @param podName       Drain Cleaner podName
+     * @param secretName    Name of the certificate Secret
+     * @param secretKeys    Keys under which the certificates are stored in the secret
+     */
+    /* test */ CertificateWatch(KubernetesClient client, boolean enabled, String namespace, String podName, String secretName, List<String> secretKeys)  {
+        this(enabled, namespace, podName, secretName, secretKeys);
+        this.client = client;
+    }
+
+    /**
+     * Private constructor used to set the right values which is called from production and from tests.
+     *
+     * @param enabled       Enables / disables the certificate watch
+     * @param namespace     Drain Cleaner namespace
+     * @param podName       Drain Cleaner podName
+     * @param secretName    Name of the certificate Secret
+     * @param secretKeys    Keys under which the certificates are stored in the secret
+     */
+    private CertificateWatch(boolean enabled, String namespace, String podName, String secretName, List<String> secretKeys)  {
+        this.enabled = enabled;
+        this.namespace = namespace;
+        this.podName = podName;
+        this.secretName = secretName;
+        this.secretKeys = secretKeys;
+
+        if (this.enabled) {
+            // Validate configuration and throw exception if something is missing
+            validateWatchConfiguration();
+        } else {
+            LOG.info("Certificate watch is disabled");
+        }
+    }
+
+    /**
+     * Starts the watcher when Quarkus is starting
+     *
+     * @param ev    Startup event
+     */
+    void onStart(@Observes StartupEvent ev) {
+        start();
+    }
+
+    /**
+     * Stops the watch when Quarkus is stopping
+     *
+     * @param ev    Shutdown event
+     */
+    void onStop(@Observes ShutdownEvent ev) {
+        stop();
+    }
+
+    /**
+     * Starts the watcher (if enabled). It will first get the secret to get the initial data. Afterwards it sets up
+     * and starts an informer to be informed about any changes to it.
+     */
+    /* test */ void start() {
+        if (enabled) {
+            LOG.info("Starting the certificate watch");
+            initialize();
+            setupInformer();
+            secretInformer.start();
+        }
+    }
+
+    /**
+     * Stops the informer
+     */
+    /* test */ void stop() {
+        if (enabled) {
+            LOG.info("Stopping the certificate watch");
+            secretInformer.stop();
+        }
+    }
+
+    /**
+     * Validates the Certificate Watch configuration and throws exception if any options are missing.
+     */
+    private void validateWatchConfiguration()   {
+        List<String> missingOptions = new ArrayList<>();
+
+        if (namespace == null)  {
+            missingOptions.add("strimzi.certificate.watch.namespace");
+        }
+
+        if (podName == null)  {
+            missingOptions.add("strimzi.certificate.watch.pod.name");
+        }
+
+        if (secretName == null)  {
+            missingOptions.add("strimzi.certificate.watch.secret.name");
+        }
+
+        if (secretKeys == null || secretKeys.isEmpty())  {
+            missingOptions.add("strimzi.certificate.watch.secret.keys");
+        }
+
+        if (!missingOptions.isEmpty())   {
+            LOG.error("Certificate watch is enabled but missing one or more required options: {}", missingOptions);
+            throw new RuntimeException("Certificate watch is enabled but missing one or more required options: " + missingOptions);
+        }
+    }
+
+    /**
+     * Gets the certificate secret and loads the initial values of the selected fields from it. The values are expected
+     * to be certificates -> small enough to just store them as a String.
+     */
+    private void initialize()   {
+        Secret watchedSecret = client.secrets().inNamespace(namespace).withName(secretName).get();
+
+        if (watchedSecret == null)  {
+            LOG.error("Certificate Secret {} which should be watched was not found", secretName);
+            throw new RuntimeException("Certificate Secret " + secretName + " which should be watched was not found");
+        } else {
+            LOG.info("Getting initial values from the secret");
+            previousValues = getSecretData(watchedSecret);
+        }
+    }
+
+    /**
+     * Sets up the Secret informer with the event handler which is triggered when the secret is added or changes. When
+     * the secret is deleted, we do not do anything -> in such case, the new Pod would not start anyway. We expect the
+     * secret to be created again later which is when we might restart if the certificates differ.
+     */
+    private void setupInformer()    {
+        secretInformer = client.secrets().inNamespace(namespace).withName(secretName).inform(new ResourceEventHandler<>() {
+            @Override
+            public void onAdd(Secret secret) {
+                LOG.info("Secret {} was added and will be checked for changes", secret.getMetadata().getName());
+                checkForChanges(secret);
+            }
+
+            @Override
+            public void onUpdate(Secret oldSecret, Secret newSecret) {
+                LOG.info("Secret {} was modified and will be checked for changes", newSecret.getMetadata().getName());
+                checkForChanges(newSecret);
+            }
+
+            @Override
+            public void onDelete(Secret secret, boolean deletedFinalStateUnknown) {
+                LOG.info("Secret {} was deleted -> nothing to do", secret.getMetadata().getName());
+            }
+        });
+    }
+
+    /**
+     * Checks the Secret for changes. It extracts the selected keys from it and compares it to the previously known
+     * value. If they differ, it triggers the restart of the Drain Cleaner.
+     *
+     * @param secret    Secret with the values which should be compared with the known certificates
+     */
+    /* test */ void checkForChanges(Secret secret) {
+        if (secret == null
+                || !previousValues.equals(getSecretData(secret))) {
+            LOG.info("The watched fields {} changed and Drain Cleaner restart will be triggered", secretKeys);
+
+            // The pod is deleted asynchronously to not block the event handler from the secretInformer
+            // Doing it synchronously was causing Fabric8 exceptions since it was blocking the thread while the informer was
+            // shutting down => because it is deleting itself
+            CompletableFuture.supplyAsync(() -> {
+                restartDrainCleaner();
+                return (Void) null;
+            });
+        } else {
+            LOG.info("No change to watched fields ({}) detected", secretKeys);
+        }
+    }
+
+    /**
+     * Restarts this Drain Cleaner Pod by deleting it through the Kubernetes API
+     */
+    /* test */ void restartDrainCleaner()  {
+        LOG.info("Deleting pod {} to restart Drain Cleaner and reload certificates", podName);
+        client.pods().inNamespace(namespace).withName(podName).delete();
+    }
+
+    /**
+     * Extracts the data from the Secret
+     *
+     * @param secret   Secret from which the data should be extracted
+     *
+     * @return  The values of selected keys from the Secret as one long String
+     */
+    private String getSecretData(Secret secret) {
+        StringBuilder sb = new StringBuilder();
+
+        if (secret.getData() != null) {
+            for (String key : secretKeys) {
+                if (secret.getData().containsKey(key)) {
+                    sb.append(secret.getData().get(key));
+                } else {
+                    LOG.warn("Watched key {} is not present in Secret {}", key, secret.getMetadata().getName());
+                }
+            }
+        } else {
+            LOG.warn("Watched Secret {} has no data", secret.getMetadata().getName());
+        }
+
+        return sb.toString();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,6 +2,14 @@
 strimzi.drain.zookeeper=true
 strimzi.drain.kafka=true
 
+# Configures the certificate watch which will automatically restart Drain Cleaner if the Secret with the TLS certificates changes
+strimzi.certificate.watch.enabled=false
+strimzi.certificate.watch.namespace=strimzi-drain-cleaner
+# Pod name should be set from environment variable using the Kubernetes Downward API
+#strimzi.certificate.watch.pod.name=
+strimzi.certificate.watch.secret.name=strimzi-drain-cleaner
+strimzi.certificate.watch.secret.keys=tls.crt,tls.key
+
 # Quarkus HTTP server configuration
 quarkus.http.port=8080
 

--- a/src/test/java/io/strimzi/CertificateWatchTest.java
+++ b/src/test/java/io/strimzi/CertificateWatchTest.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodList;
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.SecretBuilder;
+import io.fabric8.kubernetes.api.model.SecretList;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.PodResource;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.informers.ResourceEventHandler;
+import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class CertificateWatchTest {
+    private final static String NAMESPACE = "my-namespace";
+    private final static String POD_NAME = "my-pod";
+    private final static String SECRET_NAME = "my-secret";
+    private final static List<String> SECRET_KEYS = List.of("tls.crt", "tls.key");
+    private final static Secret INITIAL_SECRET = new SecretBuilder()
+            .withNewMetadata()
+                .withName(SECRET_NAME)
+                .withNamespace(NAMESPACE)
+            .endMetadata()
+            .withData(Map.of("tls.crt", "YXZmYw==", "tls.key", "MTg3NA=="))
+            .build();
+
+    KubernetesClient client;
+
+    MixedOperation<Pod, PodList, PodResource> pods;
+    NonNamespaceOperation<Pod, PodList, PodResource> podsInNamespace;
+    PodResource podResource;
+
+    MixedOperation<Secret, SecretList, Resource<Secret>> secrets;
+    NonNamespaceOperation<Secret, SecretList, Resource<Secret>> secretsInNamespace;
+    Resource<Secret> secretResource;
+    SharedIndexInformer<Secret> secretInformer;
+    ArgumentCaptor<ResourceEventHandler<Secret>> secretInformerHandlerCaptor;
+
+    @SuppressWarnings("unchecked")
+    @BeforeEach
+    public void setup() {
+        client = mock(KubernetesClient.class);
+
+        // Mock pod for deletion
+        pods = mock(MixedOperation.class);
+        podsInNamespace = mock(NonNamespaceOperation.class);
+        podResource = mock(PodResource.class);
+
+        when(podsInNamespace.withName(eq(POD_NAME))).thenReturn(podResource);
+        when(pods.inNamespace(eq(NAMESPACE))).thenReturn(podsInNamespace);
+        when(client.pods()).thenReturn(pods);
+
+        // Mock Secret
+        secrets = mock(MixedOperation.class);
+        secretsInNamespace = mock(NonNamespaceOperation.class);
+        secretResource = mock(Resource.class);
+
+        when(secretResource.get()).thenReturn(INITIAL_SECRET);
+        when(secretsInNamespace.withName(eq(SECRET_NAME))).thenReturn(secretResource);
+        when(secrets.inNamespace(eq(NAMESPACE))).thenReturn(secretsInNamespace);
+        when(client.secrets()).thenReturn(secrets);
+
+        // Mock the informer
+        secretInformer = mock(SharedIndexInformer.class);
+        secretInformerHandlerCaptor = ArgumentCaptor.forClass(ResourceEventHandler.class);
+
+        when(secretResource.inform(secretInformerHandlerCaptor.capture())).thenReturn(secretInformer);
+    }
+
+    @Test
+    public void testValidationWhenDisabled()    {
+        CertificateWatch watch = new CertificateWatch(null, false, null, null, null, null);
+        watch.start();
+        watch.stop();
+    }
+
+    @Test
+    public void testValidationFailureWhenEnabled()    {
+        RuntimeException e = assertThrows(RuntimeException.class, () -> new CertificateWatch(null, true, null, null, null, null));
+        assertThat(e.getMessage(), is("Certificate watch is enabled but missing one or more required options: [strimzi.certificate.watch.namespace, strimzi.certificate.watch.pod.name, strimzi.certificate.watch.secret.name, strimzi.certificate.watch.secret.keys]"));
+    }
+
+    @Test
+    public void testValidationWhenEnabled()    {
+        CertificateWatch watch = new CertificateWatch(client, true, NAMESPACE, POD_NAME, SECRET_NAME, SECRET_KEYS);
+        watch.start();
+        watch.stop();
+    }
+
+    @Test
+    public void testInitialization()    {
+        CertificateWatch watch = new CertificateWatch(client, true, NAMESPACE, POD_NAME, SECRET_NAME, SECRET_KEYS);
+        watch.start();
+        watch.stop();
+
+        assertThat(watch.previousValues, is("YXZmYw==MTg3NA=="));
+        verify(secretResource, times(1)).get();
+        verify(secretInformer, times(1)).start();
+        verify(secretInformer, times(1)).stop();
+        assertThat(secretInformerHandlerCaptor.getValue(), is(notNullValue()));
+    }
+
+    @Test
+    public void testPodDeletionWhenSecretChanged() throws InterruptedException {
+        CountDownLatch checked = new CountDownLatch(1);
+        CountDownLatch deleted = new CountDownLatch(1);
+
+        CertificateWatch watch = new MockedCertificateWatch(client, true, NAMESPACE, POD_NAME, SECRET_NAME, SECRET_KEYS, checked, deleted);
+        watch.start();
+
+        Secret modifiedSecret = new SecretBuilder(INITIAL_SECRET)
+                .withData(Map.of("tls.crt", "c2lnbWE=", "tls.key", "MTkxOQ=="))
+                .build();
+
+        secretInformerHandlerCaptor.getValue().onUpdate(INITIAL_SECRET, modifiedSecret);
+
+        assertThat(checked.await(1, TimeUnit.SECONDS), is(true));
+        assertThat(deleted.await(1, TimeUnit.SECONDS), is(true));
+
+        verify(podResource, times(1)).delete();
+    }
+
+    @Test
+    public void testPodDeletionWhenSecretIsAdded() throws InterruptedException {
+        CountDownLatch checked = new CountDownLatch(1);
+        CountDownLatch deleted = new CountDownLatch(1);
+
+        CertificateWatch watch = new MockedCertificateWatch(client, true, NAMESPACE, POD_NAME, SECRET_NAME, SECRET_KEYS, checked, deleted);
+        watch.start();
+
+        Secret modifiedSecret = new SecretBuilder(INITIAL_SECRET)
+                .withData(Map.of("tls.crt", "c2lnbWE=", "tls.key", "MTkxOQ=="))
+                .build();
+
+        secretInformerHandlerCaptor.getValue().onAdd(modifiedSecret);
+
+        assertThat(checked.await(1, TimeUnit.SECONDS), is(true));
+        assertThat(deleted.await(1, TimeUnit.SECONDS), is(true));
+
+        verify(podResource, times(1)).delete();
+    }
+
+    @Test
+    public void testNoPodDeletionWhenNewFieldIsAdded() throws InterruptedException {
+        CountDownLatch checked = new CountDownLatch(1);
+        CountDownLatch deleted = new CountDownLatch(1);
+
+        CertificateWatch watch = new MockedCertificateWatch(client, true, NAMESPACE, POD_NAME, SECRET_NAME, SECRET_KEYS, checked, deleted);
+        watch.start();
+
+        Secret modifiedSecret = new SecretBuilder(INITIAL_SECRET)
+                .addToData("other.file", "YmlybWluZ2hhbQ==")
+                .build();
+
+        secretInformerHandlerCaptor.getValue().onUpdate(INITIAL_SECRET, modifiedSecret);
+
+        assertThat(checked.await(1, TimeUnit.SECONDS), is(true));
+
+        verify(podResource, never()).delete();
+    }
+
+    @Test
+    public void testNoPodDeletionWhenNothingChanges() throws InterruptedException {
+        CountDownLatch checked = new CountDownLatch(1);
+        CountDownLatch deleted = new CountDownLatch(1);
+
+        CertificateWatch watch = new MockedCertificateWatch(client, true, NAMESPACE, POD_NAME, SECRET_NAME, SECRET_KEYS, checked, deleted);
+        watch.start();
+
+        secretInformerHandlerCaptor.getValue().onUpdate(INITIAL_SECRET, INITIAL_SECRET);
+
+        assertThat(checked.await(1, TimeUnit.SECONDS), is(true));
+
+        verify(podResource, never()).delete();
+    }
+
+    /**
+     * This class is used to inject countdown latches to help with the tests
+     */
+    static class MockedCertificateWatch extends CertificateWatch   {
+        private final CountDownLatch podDeletionLatch;
+        private final CountDownLatch checkForChangesLatch;
+
+        public MockedCertificateWatch(KubernetesClient client, boolean enabled, String namespace, String podName, String secretName, List<String> secretKeys, CountDownLatch checkForChangesLatch, CountDownLatch podDeletionLatch) {
+            super(client, enabled, namespace, podName, secretName, secretKeys);
+            this.checkForChangesLatch = checkForChangesLatch;
+            this.podDeletionLatch = podDeletionLatch;
+        }
+
+        @Override
+        void checkForChanges(Secret secret) {
+            super.checkForChanges(secret);
+            checkForChangesLatch.countDown();
+        }
+
+        @Override
+        void restartDrainCleaner()  {
+            super.restartDrainCleaner();
+            podDeletionLatch.countDown();
+        }
+    }
+}

--- a/src/test/java/io/strimzi/HealthCheckTest.java
+++ b/src/test/java/io/strimzi/HealthCheckTest.java
@@ -2,9 +2,8 @@
  * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-package io.strimzi.test;
+package io.strimzi;
 
-import io.strimzi.HealthCheck;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/io/strimzi/ValidatingWebhookTest.java
+++ b/src/test/java/io/strimzi/ValidatingWebhookTest.java
@@ -2,7 +2,7 @@
  * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-package io.strimzi.test;
+package io.strimzi;
 
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
@@ -15,7 +15,6 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.PodResource;
-import io.strimzi.ValidatingWebhook;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;


### PR DESCRIPTION
This PR replaces #61. #61 tried to watch the files, but that proved not to be the right approach since the behavior differed significantly across different Kubernetes distributions. 

This PR is using Kubernetes APIs to watch the Secret in Kubernetes and detect any changes that way. If a change is detected, it will delete itself (again through the Kubernetes API - that way it avoids the CrashLoop behavior from #61). It requires some additional RBAC rights, but there are fairly minimal:
* Deleting pods
* Listing, getting, and watching secrets with a single name (`strimzi-drain-cleaner` by default)

So I think this should not cause a problem. Also, the whole watching can be disabled, in which case no additional RBAC rights are needed.