### PR TITLE
[systemtest] Add Helm installation method to STs and run it on AZP

### DIFF
--- a/.azure/templates/jobs/run_systemtests.yaml
+++ b/.azure/templates/jobs/run_systemtests.yaml
@@ -46,4 +46,16 @@ jobs:
           DOCKER_REGISTRY: registry.minikube
           DOCKER_ORG: strimzi
           DOCKER_TAG: latest
-        displayName: 'Run systemtests - $(arch)'
+        displayName: 'Run systemtests - $(arch) - Bundle installation'
+      - task: Maven@3
+        inputs:
+          mavenPomFile: 'pom.xml'
+          publishJUnitResults: true
+          goals: 'verify'
+          options: '-B -Psystemtest'
+        env:
+          DOCKER_REGISTRY: registry.minikube
+          DOCKER_ORG: strimzi
+          DOCKER_TAG: latest
+          DC_INSTALL_TYPE: Helm
+        displayName: 'Run systemtests - $(arch) - Helm installation'

--- a/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -43,7 +43,7 @@ public class AbstractST {
             StUtils.deleteNamespaceWithWait(Constants.NAMESPACE);
         }
 
-        setupDrainCleaner = new SetupDrainCleaner(Constants.NAMESPACE);
+        setupDrainCleaner = new SetupDrainCleaner();
         setupDrainCleaner.deployDrainCleaner();
     }
 

--- a/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -4,128 +4,29 @@
  */
 package io.strimzi.systemtest;
 
-import io.fabric8.kubernetes.api.model.SecretBuilder;
-import io.fabric8.kubernetes.api.model.admissionregistration.v1.ValidatingWebhookConfiguration;
-import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
+import io.strimzi.utils.Constants;
 import io.strimzi.utils.StUtils;
+import io.strimzi.utils.deployment.SetupDrainCleaner;
 import io.strimzi.utils.k8s.KubeClusterResource;
 
-import io.strimzi.utils.security.CertAndKeyFiles;
-import io.strimzi.utils.security.SystemTestCertAndKey;
-import io.strimzi.utils.security.SystemTestCertManager;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.bouncycastle.asn1.ASN1Encodable;
-import org.bouncycastle.asn1.x509.GeneralName;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInfo;
 
-import java.io.File;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Stack;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Collectors;
 
-import static io.strimzi.utils.k8s.KubeClusterResource.cmdKubeClient;
 import static io.strimzi.utils.k8s.KubeClusterResource.kubeClient;
 
 public class AbstractST {
 
-    private static final String USER_PATH = System.getProperty("user.dir");
     private static final Logger LOGGER = LogManager.getLogger(AbstractST.class);
 
-    public static final String NAMESPACE = "strimzi-drain-cleaner";
-    public static final String DEPLOYMENT_NAME = "strimzi-drain-cleaner";
-    private static final String INSTALL_PATH = USER_PATH + "/packaging/install/kubernetes/";
-
     protected static KubeClusterResource cluster;
-    private static Stack<String> createdFiles = new Stack<>();
 
-    static void applyInstallFiles() {
-        List<File> drainCleanerFiles = Arrays.stream(new File(INSTALL_PATH).listFiles()).sorted()
-            .filter(File::isFile)
-            .collect(Collectors.toList());
-
-        final AtomicReference<SecretBuilder> customDrainCleanerSecretBuilder = new AtomicReference<>();
-
-        drainCleanerFiles.forEach(file -> {
-            if (!file.getName().contains("README")) {
-                if (!file.getName().contains("Deployment")) {
-                    LOGGER.info(String.format("Creating file: %s", file.getAbsolutePath()));
-
-                    if (file.getName().endsWith("040-Secret.yaml")) {
-                         // we need to create our own certificates before applying install-files
-                        final SystemTestCertAndKey drainCleanerKeyPair = SystemTestCertManager
-                            .generateRootCaCertAndKey("C=CZ, L=Prague, O=Strimzi Drain Cleaner, CN=StrimziDrainCleanerCA",
-                                // add hostnames (i.e., SANs) to the certificate
-                                new ASN1Encodable[] {
-                                    new GeneralName(GeneralName.dNSName, StUtils.DRAIN_CLEANER_DEPLOYMENT_NAME),
-                                    new GeneralName(GeneralName.dNSName, StUtils.DRAIN_CLEANER_DEPLOYMENT_NAME + "." + StUtils.DRAIN_CLEANER_DEPLOYMENT_NAME),
-                                    new GeneralName(GeneralName.dNSName, StUtils.DRAIN_CLEANER_DEPLOYMENT_NAME + "." + StUtils.DRAIN_CLEANER_DEPLOYMENT_NAME + ".svc"),
-                                    new GeneralName(GeneralName.dNSName, StUtils.DRAIN_CLEANER_DEPLOYMENT_NAME + "." + StUtils.DRAIN_CLEANER_DEPLOYMENT_NAME + ".svc.cluster.local")
-                                });
-                        final CertAndKeyFiles drainCleanerKeyPairPemFormat = SystemTestCertManager.exportToPemFiles(drainCleanerKeyPair);
-                        final Map<String, String> certsPaths = new HashMap<>();
-                        certsPaths.put("tls.crt", drainCleanerKeyPairPemFormat.getCertPath());
-                        certsPaths.put("tls.key", drainCleanerKeyPairPemFormat.getKeyPath());
-
-                        customDrainCleanerSecretBuilder.set(StUtils.retrieveSecretBuilderFromFile(certsPaths,
-                            StUtils.DRAIN_CLEANER_DEPLOYMENT_NAME, StUtils.DRAIN_CLEANER_NAMESPACE,
-                            Collections.singletonMap("app", StUtils.DRAIN_CLEANER_DEPLOYMENT_NAME), "kubernetes.io/tls"));
-
-                        // replace Secret with our own generated certificates
-                        kubeClient().getClient().secrets().inNamespace(StUtils.DRAIN_CLEANER_NAMESPACE).createOrReplace(customDrainCleanerSecretBuilder.get().build());
-                    } else if (file.getName().endsWith("070-ValidatingWebhookConfiguration.yaml")) {
-                        ValidatingWebhookConfiguration validatingWebhookConfiguration = StUtils.configFromYaml(file, ValidatingWebhookConfiguration.class);
-                        // we fetch public key from strimzi-drain-cleaner Secret and then patch ValidationWebhookConfiguration.
-                        validatingWebhookConfiguration.getWebhooks().stream().findFirst().get().getClientConfig().setCaBundle(customDrainCleanerSecretBuilder.get().getData().get("tls.crt"));
-                        kubeClient().getClient().admissionRegistration().v1().validatingWebhookConfigurations().createOrReplace(validatingWebhookConfiguration);
-                    } else {
-                        cmdKubeClient().namespace(NAMESPACE).apply(file);
-                    }
-                    createdFiles.add(file.getAbsolutePath());
-                } else {
-                    deployDrainCleaner(file);
-                }
-            }
-        });
-    }
-
-    static void deleteInstallFiles() {
-        while (!createdFiles.empty()) {
-            String fileToBeDeleted = createdFiles.pop();
-            LOGGER.info("Deleting file: {}", fileToBeDeleted);
-            cmdKubeClient().namespace(NAMESPACE).delete(fileToBeDeleted);
-        }
-    }
-
-    private static void deployDrainCleaner(File deploymentFile) {
-        Deployment drainCleanerDep = StUtils.configFromYaml(deploymentFile, Deployment.class);
-        String deploymentImage = drainCleanerDep.getSpec().getTemplate().getSpec().getContainers().get(0).getImage();
-
-        drainCleanerDep = new DeploymentBuilder(drainCleanerDep)
-            .editSpec()
-                .editTemplate()
-                    .editSpec()
-                        .editContainer(0)
-                            .withImage(StUtils.changeOrgAndTag(deploymentImage))
-                        .endContainer()
-                    .endSpec()
-                .endTemplate()
-            .endSpec()
-            .build();
-
-        createdFiles.add(deploymentFile.getAbsolutePath());
-        kubeClient().createOrReplaceDeployment(drainCleanerDep);
-        StUtils.waitForDeploymentReady(NAMESPACE, DEPLOYMENT_NAME);
-    }
+    protected static SetupDrainCleaner setupDrainCleaner;
 
     @BeforeEach
     void beforeEachTest(TestInfo testInfo) {
@@ -138,16 +39,17 @@ public class AbstractST {
         cluster = KubeClusterResource.getInstance();
 
         // simple teardown before all tests
-        if (kubeClient().getNamespace(NAMESPACE) != null) {
-            StUtils.deleteNamespaceWithWait(NAMESPACE);
+        if (kubeClient().getNamespace(Constants.NAMESPACE) != null) {
+            StUtils.deleteNamespaceWithWait(Constants.NAMESPACE);
         }
 
-        applyInstallFiles();
+        setupDrainCleaner = new SetupDrainCleaner(Constants.NAMESPACE);
+        setupDrainCleaner.deployDrainCleaner();
     }
 
     @AfterAll
     static void teardown() {
-        deleteInstallFiles();
-        StUtils.deleteNamespaceWithWait(NAMESPACE);
+        setupDrainCleaner.deleteDrainCleaner();
+        StUtils.deleteNamespaceWithWait(Constants.NAMESPACE);
     }
 }

--- a/src/test/java/io/strimzi/systemtest/DrainCleanerST.java
+++ b/src/test/java/io/strimzi/systemtest/DrainCleanerST.java
@@ -8,6 +8,7 @@ import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.api.model.apps.StatefulSetBuilder;
 import io.fabric8.kubernetes.api.model.policy.v1.PodDisruptionBudget;
 import io.fabric8.kubernetes.api.model.policy.v1.PodDisruptionBudgetBuilder;
+import io.strimzi.utils.Constants;
 import io.strimzi.utils.StUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -32,14 +33,14 @@ public class DrainCleanerST extends AbstractST {
         createStatefulSetAndPDBWithWait(stsName);
 
         LOGGER.info("Creating eviction request to the pod");
-        String podName = kubeClient().listPodsByPrefixInName(NAMESPACE, stsName).get(0).getMetadata().getName();
-        kubeClient().getClient().pods().inNamespace(NAMESPACE).withName(podName).evict();
+        String podName = kubeClient().listPodsByPrefixInName(Constants.NAMESPACE, stsName).get(0).getMetadata().getName();
+        kubeClient().getClient().pods().inNamespace(Constants.NAMESPACE).withName(podName).evict();
 
         LOGGER.info("Checking that pod annotations will contain \"{}: true\"", MANUAL_RU_ANNO);
 
-        StUtils.waitForAnnotationToAppear(NAMESPACE, podName, MANUAL_RU_ANNO);
+        StUtils.waitForAnnotationToAppear(Constants.NAMESPACE, podName, MANUAL_RU_ANNO);
 
-        Map<String, String> annotations = kubeClient().namespace(NAMESPACE).getPod(podName).getMetadata().getAnnotations();
+        Map<String, String> annotations = kubeClient().namespace(Constants.NAMESPACE).getPod(podName).getMetadata().getAnnotations();
         assertEquals("true", annotations.get(MANUAL_RU_ANNO));
     }
 
@@ -51,18 +52,18 @@ public class DrainCleanerST extends AbstractST {
         createStatefulSetAndPDBWithWait(stsName);
 
         LOGGER.info("Creating eviction request to the pod");
-        String podName = kubeClient().listPodsByPrefixInName(NAMESPACE, stsName).get(0).getMetadata().getName();
-        kubeClient().getClient().pods().inNamespace(NAMESPACE).withName(podName).evict();
+        String podName = kubeClient().listPodsByPrefixInName(Constants.NAMESPACE, stsName).get(0).getMetadata().getName();
+        kubeClient().getClient().pods().inNamespace(Constants.NAMESPACE).withName(podName).evict();
 
         LOGGER.info("Checking that pod annotations will not contain \"{}\"", MANUAL_RU_ANNO);
-        StUtils.waitForAnnotationToNotAppear(NAMESPACE, podName, MANUAL_RU_ANNO);
+        StUtils.waitForAnnotationToNotAppear(Constants.NAMESPACE, podName, MANUAL_RU_ANNO);
     }
 
     void createStatefulSetAndPDBWithWait(String stsName) {
         StatefulSet statefulSet = new StatefulSetBuilder()
             .withNewMetadata()
                 .withName(stsName)
-                .withNamespace(NAMESPACE)
+                .withNamespace(Constants.NAMESPACE)
             .endMetadata()
             .withNewSpec()
                 .withReplicas(1)
@@ -88,7 +89,7 @@ public class DrainCleanerST extends AbstractST {
         PodDisruptionBudget pdb = new PodDisruptionBudgetBuilder()
             .withNewMetadata()
                 .withName(stsName + "-pdb")
-                .withNamespace(NAMESPACE)
+                .withNamespace(Constants.NAMESPACE)
             .endMetadata()
             .withNewSpec()
                 .withNewMaxUnavailable(0)

--- a/src/test/java/io/strimzi/utils/Constants.java
+++ b/src/test/java/io/strimzi/utils/Constants.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.utils;
+
+public interface Constants {
+    String USER_PATH = System.getProperty("user.dir");
+    String INSTALL_PATH = USER_PATH + "/packaging/install/kubernetes/";
+    String DEPLOYMENT_NAME = "strimzi-drain-cleaner";
+    String NAMESPACE = "strimzi-drain-cleaner";
+    String DEPLOYMENT = "deployment";
+}

--- a/src/test/java/io/strimzi/utils/Environment.java
+++ b/src/test/java/io/strimzi/utils/Environment.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.utils;
 
+import io.strimzi.utils.enums.InstallType;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -21,9 +22,12 @@ public class Environment {
 
     private static final String CLEANER_TAG_ENV = "DOCKER_TAG";
 
+    private static final String INSTALL_TYPE_ENV = "DC_INSTALL_TYPE";
+
     public static final String CLEANER_REGISTRY = getOrDefault(CLEANER_REGISTRY_ENV, null);
     public static final String CLEANER_ORG = getOrDefault(CLEANER_ORG_ENV, null);
     public static final String CLEANER_TAG = getOrDefault(CLEANER_TAG_ENV, null);
+    public static final InstallType INSTALL_TYPE = getInstallTypeOrDefault(INSTALL_TYPE_ENV, InstallType.Bundle);
 
     static {
         String debugFormat = "{}: {}";
@@ -37,5 +41,11 @@ public class Environment {
         String value = System.getenv(var) != null ? System.getenv(var) : defaultValue;
         VALUES.put(var, value);
         return value;
+    }
+
+    private static InstallType getInstallTypeOrDefault(String var, InstallType defaultValue) {
+        InstallType value = System.getenv(var) != null ? InstallType.fromString(System.getenv(var)) : defaultValue;
+        VALUES.put(var, value.toString());
+        return defaultValue;
     }
 }

--- a/src/test/java/io/strimzi/utils/Environment.java
+++ b/src/test/java/io/strimzi/utils/Environment.java
@@ -46,6 +46,6 @@ public class Environment {
     private static InstallType getInstallTypeOrDefault(String var, InstallType defaultValue) {
         InstallType value = System.getenv(var) != null ? InstallType.fromString(System.getenv(var)) : defaultValue;
         VALUES.put(var, value.toString());
-        return defaultValue;
+        return value;
     }
 }

--- a/src/test/java/io/strimzi/utils/SecretUtils.java
+++ b/src/test/java/io/strimzi/utils/SecretUtils.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.utils;
+
+import io.fabric8.kubernetes.api.model.SecretBuilder;
+import io.strimzi.utils.security.CertAndKeyFiles;
+import io.strimzi.utils.security.SystemTestCertAndKey;
+import io.strimzi.utils.security.SystemTestCertManager;
+import org.bouncycastle.asn1.ASN1Encodable;
+import org.bouncycastle.asn1.x509.GeneralName;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.strimzi.utils.k8s.KubeClusterResource.kubeClient;
+
+public class SecretUtils {
+    public static SecretBuilder createDrainCleanerSecret() {
+        // we need to create our own certificates before applying install-files
+        final SystemTestCertAndKey drainCleanerKeyPair = SystemTestCertManager
+            .generateRootCaCertAndKey("C=CZ, L=Prague, O=Strimzi Drain Cleaner, CN=StrimziDrainCleanerCA",
+                // add hostnames (i.e., SANs) to the certificate
+                new ASN1Encodable[] {
+                    new GeneralName(GeneralName.dNSName, StUtils.DRAIN_CLEANER_DEPLOYMENT_NAME),
+                    new GeneralName(GeneralName.dNSName, StUtils.DRAIN_CLEANER_DEPLOYMENT_NAME + "." + StUtils.DRAIN_CLEANER_DEPLOYMENT_NAME),
+                    new GeneralName(GeneralName.dNSName, StUtils.DRAIN_CLEANER_DEPLOYMENT_NAME + "." + StUtils.DRAIN_CLEANER_DEPLOYMENT_NAME + ".svc"),
+                    new GeneralName(GeneralName.dNSName, StUtils.DRAIN_CLEANER_DEPLOYMENT_NAME + "." + StUtils.DRAIN_CLEANER_DEPLOYMENT_NAME + ".svc.cluster.local")
+                });
+        final CertAndKeyFiles drainCleanerKeyPairPemFormat = SystemTestCertManager.exportToPemFiles(drainCleanerKeyPair);
+        final Map<String, String> certsPaths = new HashMap<>();
+        certsPaths.put("tls.crt", drainCleanerKeyPairPemFormat.getCertPath());
+        certsPaths.put("tls.key", drainCleanerKeyPairPemFormat.getKeyPath());
+
+        SecretBuilder secretBuilder = retrieveSecretBuilderFromFile(certsPaths,
+                StUtils.DRAIN_CLEANER_DEPLOYMENT_NAME, StUtils.DRAIN_CLEANER_NAMESPACE,
+                Collections.singletonMap("app", StUtils.DRAIN_CLEANER_DEPLOYMENT_NAME), "kubernetes.io/tls");
+
+        // replace Secret with our own generated certificates
+        kubeClient().getClient().secrets().inNamespace(StUtils.DRAIN_CLEANER_NAMESPACE).createOrReplace(secretBuilder.build());
+
+        return secretBuilder;
+    }
+
+    public static SecretBuilder retrieveSecretBuilderFromFile(final Map<String, String> certFilesPath, final String name,
+                                                              final String namespace, final Map<String, String> labels,
+                                                              final String secretType) {
+        byte[] encoded;
+        final Map<String, String> data = new HashMap<>();
+
+        try {
+            for (final Map.Entry<String, String> entry : certFilesPath.entrySet()) {
+                encoded = Files.readAllBytes(Paths.get(entry.getValue()));
+
+                final Base64.Encoder encoder = Base64.getEncoder();
+                data.put(entry.getKey(), encoder.encodeToString(encoded));
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        return new SecretBuilder()
+            .withType(secretType)
+            .withData(data)
+            .withNewMetadata()
+                .withName(name)
+                .withNamespace(namespace)
+                .addToLabels(labels)
+            .endMetadata();
+    }
+}

--- a/src/test/java/io/strimzi/utils/StUtils.java
+++ b/src/test/java/io/strimzi/utils/StUtils.java
@@ -10,7 +10,6 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.fabric8.kubernetes.api.model.ContainerStatus;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.Pod;
-import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.api.model.policy.v1.PodDisruptionBudget;
 import io.fabric8.kubernetes.client.readiness.Readiness;
@@ -23,13 +22,8 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.time.Duration;
-import java.util.Base64;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.function.BooleanSupplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -296,33 +290,6 @@ public final class StUtils {
         }
 
         return image;
-    }
-
-    public static SecretBuilder retrieveSecretBuilderFromFile(final Map<String, String> certFilesPath, final String name,
-                                                              final String namespace, final Map<String, String> labels,
-                                                              final String secretType) {
-        byte[] encoded;
-        final Map<String, String> data = new HashMap<>();
-
-        try {
-            for (final Map.Entry<String, String> entry : certFilesPath.entrySet()) {
-                encoded = Files.readAllBytes(Paths.get(entry.getValue()));
-
-                final Base64.Encoder encoder = Base64.getEncoder();
-                data.put(entry.getKey(), encoder.encodeToString(encoded));
-            }
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-
-        return new SecretBuilder()
-            .withType(secretType)
-            .withData(data)
-            .withNewMetadata()
-                .withName(name)
-                .withNamespace(namespace)
-                .addToLabels(labels)
-            .endMetadata();
     }
 
     private static String setImageProperties(String current, String envVar) {

--- a/src/test/java/io/strimzi/utils/deployment/SetupDrainCleaner.java
+++ b/src/test/java/io/strimzi/utils/deployment/SetupDrainCleaner.java
@@ -11,11 +11,9 @@ import io.strimzi.utils.deployment.installation.InstallationMethod;
 import io.strimzi.utils.enums.InstallType;
 
 public class SetupDrainCleaner {
-    private String namespaceName;
     private InstallationMethod installationMethod;
 
-    public SetupDrainCleaner(String namespaceName) {
-        this.namespaceName = namespaceName;
+    public SetupDrainCleaner() {
         this.installationMethod = getInstallationMethod();
     }
 
@@ -28,6 +26,6 @@ public class SetupDrainCleaner {
     }
 
     private InstallationMethod getInstallationMethod() {
-        return Environment.INSTALL_TYPE == InstallType.Helm ? new HelmInstallation(namespaceName) : new BundleInstallation(namespaceName);
+        return Environment.INSTALL_TYPE == InstallType.Helm ? new HelmInstallation() : new BundleInstallation();
     }
 }

--- a/src/test/java/io/strimzi/utils/deployment/SetupDrainCleaner.java
+++ b/src/test/java/io/strimzi/utils/deployment/SetupDrainCleaner.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.utils.deployment;
+
+import io.strimzi.utils.Environment;
+import io.strimzi.utils.deployment.installation.BundleInstallation;
+import io.strimzi.utils.deployment.installation.HelmInstallation;
+import io.strimzi.utils.deployment.installation.InstallationMethod;
+import io.strimzi.utils.enums.InstallType;
+
+public class SetupDrainCleaner {
+    private String namespaceName;
+    private InstallationMethod installationMethod;
+
+    public SetupDrainCleaner(String namespaceName) {
+        this.namespaceName = namespaceName;
+        this.installationMethod = getInstallationMethod();
+    }
+
+    public void deployDrainCleaner() {
+        installationMethod.deploy();
+    }
+
+    public void deleteDrainCleaner() {
+        installationMethod.delete();
+    }
+
+    private InstallationMethod getInstallationMethod() {
+        return Environment.INSTALL_TYPE == InstallType.Helm ? new HelmInstallation(namespaceName) : new BundleInstallation(namespaceName);
+    }
+}

--- a/src/test/java/io/strimzi/utils/deployment/installation/BundleInstallation.java
+++ b/src/test/java/io/strimzi/utils/deployment/installation/BundleInstallation.java
@@ -28,10 +28,6 @@ public class BundleInstallation extends InstallationMethod {
     private static final Logger LOGGER = LogManager.getLogger(BundleInstallation.class);
     private static Stack<String> createdFiles = new Stack<>();
 
-    public BundleInstallation(String namespaceName) {
-        super(namespaceName);
-    }
-
     @Override
     public void deploy() {
         List<File> drainCleanerFiles = Arrays.stream(new File(Constants.INSTALL_PATH).listFiles()).sorted()
@@ -54,7 +50,7 @@ public class BundleInstallation extends InstallationMethod {
                         validatingWebhookConfiguration.getWebhooks().stream().findFirst().get().getClientConfig().setCaBundle(customDrainCleanerSecretBuilder.get().getData().get("tls.crt"));
                         kubeClient().getClient().admissionRegistration().v1().validatingWebhookConfigurations().createOrReplace(validatingWebhookConfiguration);
                     } else {
-                        cmdKubeClient().namespace(this.getNamespaceName()).apply(file);
+                        cmdKubeClient().namespace(Constants.NAMESPACE).apply(file);
                     }
                     createdFiles.add(file.getAbsolutePath());
                 } else {
@@ -69,7 +65,7 @@ public class BundleInstallation extends InstallationMethod {
         while (!createdFiles.empty()) {
             String fileToBeDeleted = createdFiles.pop();
             LOGGER.info("Deleting file: {}", fileToBeDeleted);
-            cmdKubeClient().namespace(this.getNamespaceName()).delete(fileToBeDeleted);
+            cmdKubeClient().namespace(Constants.NAMESPACE).delete(fileToBeDeleted);
         }
     }
 
@@ -91,6 +87,6 @@ public class BundleInstallation extends InstallationMethod {
 
         createdFiles.add(deploymentFile.getAbsolutePath());
         kubeClient().createOrReplaceDeployment(drainCleanerDep);
-        StUtils.waitForDeploymentReady(this.getNamespaceName(), Constants.DEPLOYMENT_NAME);
+        StUtils.waitForDeploymentReady(Constants.NAMESPACE, Constants.DEPLOYMENT_NAME);
     }
 }

--- a/src/test/java/io/strimzi/utils/deployment/installation/BundleInstallation.java
+++ b/src/test/java/io/strimzi/utils/deployment/installation/BundleInstallation.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.utils.deployment.installation;
+
+import io.fabric8.kubernetes.api.model.SecretBuilder;
+import io.fabric8.kubernetes.api.model.admissionregistration.v1.ValidatingWebhookConfiguration;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
+import io.strimzi.utils.Constants;
+import io.strimzi.utils.StUtils;
+import io.strimzi.utils.security.CertAndKeyFiles;
+import io.strimzi.utils.security.SystemTestCertAndKey;
+import io.strimzi.utils.security.SystemTestCertManager;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.bouncycastle.asn1.ASN1Encodable;
+import org.bouncycastle.asn1.x509.GeneralName;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Stack;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+import static io.strimzi.utils.k8s.KubeClusterResource.cmdKubeClient;
+import static io.strimzi.utils.k8s.KubeClusterResource.kubeClient;
+
+public class BundleInstallation extends InstallationMethod {
+    private static final Logger LOGGER = LogManager.getLogger(BundleInstallation.class);
+    private static Stack<String> createdFiles = new Stack<>();
+
+    public BundleInstallation(String namespaceName) {
+        super(namespaceName);
+    }
+
+    @Override
+    public void deploy() {
+        List<File> drainCleanerFiles = Arrays.stream(new File(Constants.INSTALL_PATH).listFiles()).sorted()
+                .filter(File::isFile)
+                .collect(Collectors.toList());
+
+        final AtomicReference<SecretBuilder> customDrainCleanerSecretBuilder = new AtomicReference<>();
+
+        drainCleanerFiles.forEach(file -> {
+            if (!file.getName().contains("README")) {
+                if (!file.getName().contains("Deployment")) {
+                    LOGGER.info(String.format("Creating file: %s", file.getAbsolutePath()));
+
+                    if (file.getName().endsWith("040-Secret.yaml")) {
+                        // we need to create our own certificates before applying install-files
+                        final SystemTestCertAndKey drainCleanerKeyPair = SystemTestCertManager
+                            .generateRootCaCertAndKey("C=CZ, L=Prague, O=Strimzi Drain Cleaner, CN=StrimziDrainCleanerCA",
+                                    // add hostnames (i.e., SANs) to the certificate
+                                    new ASN1Encodable[] {
+                                        new GeneralName(GeneralName.dNSName, StUtils.DRAIN_CLEANER_DEPLOYMENT_NAME),
+                                        new GeneralName(GeneralName.dNSName, StUtils.DRAIN_CLEANER_DEPLOYMENT_NAME + "." + StUtils.DRAIN_CLEANER_DEPLOYMENT_NAME),
+                                        new GeneralName(GeneralName.dNSName, StUtils.DRAIN_CLEANER_DEPLOYMENT_NAME + "." + StUtils.DRAIN_CLEANER_DEPLOYMENT_NAME + ".svc"),
+                                        new GeneralName(GeneralName.dNSName, StUtils.DRAIN_CLEANER_DEPLOYMENT_NAME + "." + StUtils.DRAIN_CLEANER_DEPLOYMENT_NAME + ".svc.cluster.local")
+                                    });
+                        final CertAndKeyFiles drainCleanerKeyPairPemFormat = SystemTestCertManager.exportToPemFiles(drainCleanerKeyPair);
+                        final Map<String, String> certsPaths = new HashMap<>();
+                        certsPaths.put("tls.crt", drainCleanerKeyPairPemFormat.getCertPath());
+                        certsPaths.put("tls.key", drainCleanerKeyPairPemFormat.getKeyPath());
+
+                        customDrainCleanerSecretBuilder.set(StUtils.retrieveSecretBuilderFromFile(certsPaths,
+                                StUtils.DRAIN_CLEANER_DEPLOYMENT_NAME, StUtils.DRAIN_CLEANER_NAMESPACE,
+                                Collections.singletonMap("app", StUtils.DRAIN_CLEANER_DEPLOYMENT_NAME), "kubernetes.io/tls"));
+
+                        // replace Secret with our own generated certificates
+                        kubeClient().getClient().secrets().inNamespace(StUtils.DRAIN_CLEANER_NAMESPACE).createOrReplace(customDrainCleanerSecretBuilder.get().build());
+                    } else if (file.getName().endsWith("070-ValidatingWebhookConfiguration.yaml")) {
+                        ValidatingWebhookConfiguration validatingWebhookConfiguration = StUtils.configFromYaml(file, ValidatingWebhookConfiguration.class);
+                        // we fetch public key from strimzi-drain-cleaner Secret and then patch ValidationWebhookConfiguration.
+                        validatingWebhookConfiguration.getWebhooks().stream().findFirst().get().getClientConfig().setCaBundle(customDrainCleanerSecretBuilder.get().getData().get("tls.crt"));
+                        kubeClient().getClient().admissionRegistration().v1().validatingWebhookConfigurations().createOrReplace(validatingWebhookConfiguration);
+                    } else {
+                        cmdKubeClient().namespace(this.getNamespaceName()).apply(file);
+                    }
+                    createdFiles.add(file.getAbsolutePath());
+                } else {
+                    deployDrainCleaner(file);
+                }
+            }
+        });
+    }
+
+    @Override
+    public void delete() {
+        while (!createdFiles.empty()) {
+            String fileToBeDeleted = createdFiles.pop();
+            LOGGER.info("Deleting file: {}", fileToBeDeleted);
+            cmdKubeClient().namespace(this.getNamespaceName()).delete(fileToBeDeleted);
+        }
+    }
+
+    private void deployDrainCleaner(File deploymentFile) {
+        Deployment drainCleanerDep = StUtils.configFromYaml(deploymentFile, Deployment.class);
+        String deploymentImage = drainCleanerDep.getSpec().getTemplate().getSpec().getContainers().get(0).getImage();
+
+        drainCleanerDep = new DeploymentBuilder(drainCleanerDep)
+            .editSpec()
+                .editTemplate()
+                    .editSpec()
+                        .editContainer(0)
+                            .withImage(StUtils.changeOrgAndTag(deploymentImage))
+                        .endContainer()
+                    .endSpec()
+                .endTemplate()
+            .endSpec()
+            .build();
+
+        createdFiles.add(deploymentFile.getAbsolutePath());
+        kubeClient().createOrReplaceDeployment(drainCleanerDep);
+        StUtils.waitForDeploymentReady(this.getNamespaceName(), Constants.DEPLOYMENT_NAME);
+    }
+}

--- a/src/test/java/io/strimzi/utils/deployment/installation/HelmInstallation.java
+++ b/src/test/java/io/strimzi/utils/deployment/installation/HelmInstallation.java
@@ -26,10 +26,6 @@ public class HelmInstallation extends InstallationMethod {
     public static final String HELM_RELEASE_NAME = "drain-cleaner-systemtests";
     private static final Logger LOGGER = LogManager.getLogger(HelmInstallation.class);
 
-    public HelmInstallation(String namespaceName) {
-        super(namespaceName);
-    }
-
     @Override
     public void deploy() {
         // create DC namespace
@@ -68,13 +64,13 @@ public class HelmInstallation extends InstallationMethod {
         Path pathToChart = new File(HELM_CHART).toPath();
         LOGGER.info("Installing DrainCleaner via Helm");
         helmClusterClient().install(pathToChart, HELM_RELEASE_NAME, values);
-        StUtils.waitForDeploymentReady(this.getNamespaceName(), Constants.DEPLOYMENT_NAME);
+        StUtils.waitForDeploymentReady(Constants.NAMESPACE, Constants.DEPLOYMENT_NAME);
     }
 
     @Override
     public void delete() {
         LOGGER.info("Deleting DrainCleaner via Helm");
         helmClusterClient().delete(HELM_RELEASE_NAME);
-        StUtils.waitForDeploymentDeletion(this.getNamespaceName(), Constants.DEPLOYMENT_NAME);
+        StUtils.waitForDeploymentDeletion(Constants.NAMESPACE, Constants.DEPLOYMENT_NAME);
     }
 }

--- a/src/test/java/io/strimzi/utils/deployment/installation/HelmInstallation.java
+++ b/src/test/java/io/strimzi/utils/deployment/installation/HelmInstallation.java
@@ -4,9 +4,13 @@
  */
 package io.strimzi.utils.deployment.installation;
 
+import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.strimzi.utils.Constants;
 import io.strimzi.utils.Environment;
+import io.strimzi.utils.SecretUtils;
 import io.strimzi.utils.StUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.File;
 import java.nio.file.Path;
@@ -14,11 +18,13 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static io.strimzi.utils.k8s.KubeClusterResource.helmClusterClient;
+import static io.strimzi.utils.k8s.KubeClusterResource.kubeClient;
 
 public class HelmInstallation extends InstallationMethod {
 
-    public static final String HELM_CHART = Constants.USER_PATH + "/../packaging/helm-charts/helm3/strimzi-drain-cleaner/";
+    public static final String HELM_CHART = Constants.USER_PATH + "/packaging/helm-charts/helm3/strimzi-drain-cleaner/";
     public static final String HELM_RELEASE_NAME = "drain-cleaner-systemtests";
+    private static final Logger LOGGER = LogManager.getLogger(HelmInstallation.class);
 
     public HelmInstallation(String namespaceName) {
         super(namespaceName);
@@ -26,25 +32,49 @@ public class HelmInstallation extends InstallationMethod {
 
     @Override
     public void deploy() {
+        // create DC namespace
+        kubeClient().createNamespace(Constants.NAMESPACE);
+
+        // create DC secret with our own certificate
+        LOGGER.info("Creating secret in {} namespace", Constants.NAMESPACE);
+        SecretBuilder secretBuilder = SecretUtils.createDrainCleanerSecret();
+
         Map<String, Object> values = new HashMap<>();
-        // image registry config
-        values.put("defaultImageRegistry", Environment.CLEANER_REGISTRY);
 
-        // image repository config
-        values.put("defaultImageRepository", Environment.CLEANER_ORG);
+        if (Environment.CLEANER_REGISTRY != null) {
+            // image registry config
+            values.put("defaultImageRegistry", Environment.CLEANER_REGISTRY);
+        }
 
-        // image tags config
-        values.put("defaultImageTag", Environment.CLEANER_TAG);
+        if (Environment.CLEANER_ORG != null) {
+            // image repository config
+            values.put("defaultImageRepository", Environment.CLEANER_ORG);
+        }
 
+        if (Environment.CLEANER_TAG != null) {
+            // image tags config
+            values.put("defaultImageTag", Environment.CLEANER_TAG);
+        }
+
+        // don't deploy certificate and issuer
+        values.put("certManager.create", "false");
+
+        // pass caBundle to installation
+        values.put("secret.ca_bundle", secretBuilder.getData().get("tls.crt"));
+
+        // don't deploy namespace
+        values.put("namespace.create", "false");
 
         Path pathToChart = new File(HELM_CHART).toPath();
+        LOGGER.info("Installing DrainCleaner via Helm");
         helmClusterClient().install(pathToChart, HELM_RELEASE_NAME, values);
         StUtils.waitForDeploymentReady(this.getNamespaceName(), Constants.DEPLOYMENT_NAME);
     }
 
     @Override
     public void delete() {
-        helmClusterClient().delete(this.getNamespaceName(), HELM_RELEASE_NAME);
+        LOGGER.info("Deleting DrainCleaner via Helm");
+        helmClusterClient().delete(HELM_RELEASE_NAME);
         StUtils.waitForDeploymentDeletion(this.getNamespaceName(), Constants.DEPLOYMENT_NAME);
     }
 }

--- a/src/test/java/io/strimzi/utils/deployment/installation/HelmInstallation.java
+++ b/src/test/java/io/strimzi/utils/deployment/installation/HelmInstallation.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.utils.deployment.installation;
+
+import io.strimzi.utils.Constants;
+import io.strimzi.utils.Environment;
+import io.strimzi.utils.StUtils;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.strimzi.utils.k8s.KubeClusterResource.helmClusterClient;
+
+public class HelmInstallation extends InstallationMethod {
+
+    public static final String HELM_CHART = Constants.USER_PATH + "/../packaging/helm-charts/helm3/strimzi-drain-cleaner/";
+    public static final String HELM_RELEASE_NAME = "drain-cleaner-systemtests";
+
+    public HelmInstallation(String namespaceName) {
+        super(namespaceName);
+    }
+
+    @Override
+    public void deploy() {
+        Map<String, Object> values = new HashMap<>();
+        // image registry config
+        values.put("defaultImageRegistry", Environment.CLEANER_REGISTRY);
+
+        // image repository config
+        values.put("defaultImageRepository", Environment.CLEANER_ORG);
+
+        // image tags config
+        values.put("defaultImageTag", Environment.CLEANER_TAG);
+
+
+        Path pathToChart = new File(HELM_CHART).toPath();
+        helmClusterClient().install(pathToChart, HELM_RELEASE_NAME, values);
+        StUtils.waitForDeploymentReady(this.getNamespaceName(), Constants.DEPLOYMENT_NAME);
+    }
+
+    @Override
+    public void delete() {
+        helmClusterClient().delete(this.getNamespaceName(), HELM_RELEASE_NAME);
+        StUtils.waitForDeploymentDeletion(this.getNamespaceName(), Constants.DEPLOYMENT_NAME);
+    }
+}

--- a/src/test/java/io/strimzi/utils/deployment/installation/InstallationMethod.java
+++ b/src/test/java/io/strimzi/utils/deployment/installation/InstallationMethod.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.utils.deployment.installation;
+
+public class InstallationMethod {
+    private String namespaceName;
+    public InstallationMethod(String namespaceName) {
+        this.namespaceName = namespaceName;
+    }
+
+    /**
+     * Deploy Drain Cleaner
+     */
+    public void deploy() {
+
+    }
+
+    /**
+     * Delete Drain Cleaner
+     */
+    public void delete() {
+
+    }
+    public String getNamespaceName() {
+        return this.namespaceName;
+    }
+}

--- a/src/test/java/io/strimzi/utils/deployment/installation/InstallationMethod.java
+++ b/src/test/java/io/strimzi/utils/deployment/installation/InstallationMethod.java
@@ -4,27 +4,14 @@
  */
 package io.strimzi.utils.deployment.installation;
 
-public class InstallationMethod {
-    private String namespaceName;
-    public InstallationMethod(String namespaceName) {
-        this.namespaceName = namespaceName;
-    }
-
+public abstract class InstallationMethod {
     /**
      * Deploy Drain Cleaner
      */
-    public void deploy() {
-
-    }
+    public abstract void deploy();
 
     /**
      * Delete Drain Cleaner
      */
-    public void delete() {
-
-    }
-
-    public String getNamespaceName() {
-        return this.namespaceName;
-    }
+    public abstract void delete();
 }

--- a/src/test/java/io/strimzi/utils/deployment/installation/InstallationMethod.java
+++ b/src/test/java/io/strimzi/utils/deployment/installation/InstallationMethod.java
@@ -23,6 +23,7 @@ public class InstallationMethod {
     public void delete() {
 
     }
+
     public String getNamespaceName() {
         return this.namespaceName;
     }

--- a/src/test/java/io/strimzi/utils/enums/InstallType.java
+++ b/src/test/java/io/strimzi/utils/enums/InstallType.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.utils.enums;
+
+public enum InstallType {
+    Bundle,
+    Helm,
+    Unknown;
+
+    public static InstallType fromString(String text) {
+        for (InstallType installType : InstallType.values()) {
+            if (installType.toString().equalsIgnoreCase(text)) {
+                return installType;
+            }
+        }
+        return Unknown;
+    }
+}

--- a/src/test/java/io/strimzi/utils/k8s/HelmClient.java
+++ b/src/test/java/io/strimzi/utils/k8s/HelmClient.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.utils.k8s;
+
+import io.strimzi.utils.executor.Exec;
+import io.strimzi.utils.k8s.cmdClient.KubeCmdClient;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.util.Arrays.asList;
+
+public class HelmClient {
+    private static final Logger LOGGER = LogManager.getLogger(HelmClient.class);
+
+    private static final String HELM_CMD = "helm";
+    private static final String HELM_3_CMD = "helm3";
+    private static final String INSTALL_TIMEOUT_SECONDS = "120s";
+
+    private String namespace;
+
+    private static String helmCommand = HELM_CMD;
+
+    public HelmClient(String namespace) {
+        this.namespace = namespace;
+    }
+
+    public HelmClient namespace(String namespace) {
+        return new HelmClient(namespace);
+    }
+
+    /** Install a chart given its local path, release name, and values to override */
+    public HelmClient install(Path chart, String releaseName, Map<String, Object> valuesMap) {
+        LOGGER.info("Installing helm-chart {}", releaseName);
+        String values = Stream.of(valuesMap).flatMap(m -> m.entrySet().stream())
+                .map(entry -> String.format("%s=%s", entry.getKey(), entry.getValue()))
+                .collect(Collectors.joining(","));
+        Exec.exec(null, wait(namespace(command("install",
+                releaseName,
+                "--set", values,
+                "--timeout", INSTALL_TIMEOUT_SECONDS,
+                "--debug",
+                chart.toString()))), 0, true);
+        return this;
+    }
+
+    /** Delete a chart given its release name */
+    public HelmClient delete(String releaseName) {
+        LOGGER.info("Deleting helm-chart {}", releaseName);
+        delete(namespace, releaseName);
+        return this;
+    }
+
+    /**
+     * Delete a Helm chart in specific namespace by given release name
+     * @param namespace namespace where chart is installed
+     * @param releaseName helm chart release name
+     * @return this
+     */
+    public HelmClient delete(String namespace, String releaseName) {
+        LOGGER.info("Deleting helm-chart:{} in namespace:{}", releaseName, namespace);
+        Exec.exec(null, command("delete", releaseName, "--namespace", namespace), 0, false);
+        return this;
+    }
+
+    public static boolean clientAvailable() {
+        if (Exec.isExecutableOnPath(HELM_CMD)) {
+            return true;
+        } else if (Exec.isExecutableOnPath(HELM_3_CMD)) {
+            helmCommand = HELM_3_CMD;
+            return true;
+        }
+        return false;
+    }
+
+    private List<String> command(String... rest) {
+        List<String> result = new ArrayList<>();
+        result.add(helmCommand);
+        result.addAll(asList(rest));
+        return result;
+    }
+
+    /** Sets namespace for client */
+    private List<String> namespace(List<String> args) {
+        args.add("--namespace");
+        args.add(namespace);
+        return args;
+    }
+
+    private List<String> wait(List<String> args) {
+        args.add("--wait");
+        return args;
+    }
+
+    static HelmClient findClient(KubeCmdClient<?> kubeClient) {
+        HelmClient client = new HelmClient(kubeClient.namespace());
+        if (!client.clientAvailable()) {
+            throw new RuntimeException("No helm client found on $PATH. $PATH=" + System.getenv("PATH"));
+        }
+        return client;
+    }
+}

--- a/src/test/java/io/strimzi/utils/k8s/HelmClient.java
+++ b/src/test/java/io/strimzi/utils/k8s/HelmClient.java
@@ -21,7 +21,6 @@ public class HelmClient {
     private static final Logger LOGGER = LogManager.getLogger(HelmClient.class);
 
     private static final String HELM_CMD = "helm";
-    private static final String HELM_3_CMD = "helm3";
     private static final String INSTALL_TIMEOUT_SECONDS = "120s";
 
     private static String helmCommand = HELM_CMD;
@@ -55,9 +54,6 @@ public class HelmClient {
 
     public static boolean clientAvailable() {
         if (Exec.isExecutableOnPath(HELM_CMD)) {
-            return true;
-        } else if (Exec.isExecutableOnPath(HELM_3_CMD)) {
-            helmCommand = HELM_3_CMD;
             return true;
         }
         return false;

--- a/src/test/java/io/strimzi/utils/k8s/KubeClient.java
+++ b/src/test/java/io/strimzi/utils/k8s/KubeClient.java
@@ -122,6 +122,13 @@ public class KubeClient {
     }
 
     /**
+     * Gets deployment
+     */
+    public Deployment getDeployment(String namespaceName, String deploymentName) {
+        return client.apps().deployments().inNamespace(namespaceName).withName(deploymentName).get();
+    }
+
+    /**
      * Gets deployment status
      */
     public boolean getDeploymentStatus(String namespaceName, String deploymentName) {

--- a/src/test/java/io/strimzi/utils/k8s/KubeClient.java
+++ b/src/test/java/io/strimzi/utils/k8s/KubeClient.java
@@ -7,6 +7,7 @@ package io.strimzi.utils.k8s;
 import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.Namespace;
+import io.fabric8.kubernetes.api.model.NamespaceBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -45,6 +46,11 @@ public class KubeClient {
 
     public Namespace getNamespace(String namespace) {
         return client.namespaces().withName(namespace).get();
+    }
+
+    public void createNamespace(String namespaceName) {
+        Namespace ns = new NamespaceBuilder().withNewMetadata().withName(namespaceName).endMetadata().build();
+        client.namespaces().resource(ns).createOrReplace();
     }
 
     public void deleteNamespace(String name) {

--- a/src/test/java/io/strimzi/utils/k8s/KubeClusterResource.java
+++ b/src/test/java/io/strimzi/utils/k8s/KubeClusterResource.java
@@ -107,7 +107,7 @@ public class KubeClusterResource {
      * @return Helm client
      */
     public static HelmClient helmClusterClient() {
-        return kubeClusterResource.helmClient().namespace(kubeClusterResource.getNamespace());
+        return kubeClusterResource.helmClient();
     }
 
     public KubeCmdClient cmdClient() {
@@ -126,7 +126,7 @@ public class KubeClusterResource {
 
     public HelmClient helmClient() {
         if (helmClient == null) {
-            this.helmClient = HelmClient.findClient(cmdClient());
+            this.helmClient = HelmClient.findClient();
         }
         return helmClient;
     }

--- a/src/test/java/io/strimzi/utils/k8s/KubeClusterResource.java
+++ b/src/test/java/io/strimzi/utils/k8s/KubeClusterResource.java
@@ -29,6 +29,7 @@ public class KubeClusterResource {
     private KubeCluster kubeCluster;
     private KubeCmdClient cmdClient;
     private KubeClient client;
+    private HelmClient helmClient;
     private static KubeClusterResource kubeClusterResource;
 
     private String namespace;
@@ -101,6 +102,14 @@ public class KubeClusterResource {
         return kubeClusterResource.client().namespace(inNamespace);
     }
 
+    /**
+     * Provides approriate Helm client for running Helm operations in specific namespace
+     * @return Helm client
+     */
+    public static HelmClient helmClusterClient() {
+        return kubeClusterResource.helmClient().namespace(kubeClusterResource.getNamespace());
+    }
+
     public KubeCmdClient cmdClient() {
         if (cmdClient == null) {
             cmdClient = cluster().defaultCmdClient();
@@ -113,6 +122,13 @@ public class KubeClusterResource {
             this.client = cluster().defaultClient();
         }
         return client;
+    }
+
+    public HelmClient helmClient() {
+        if (helmClient == null) {
+            this.helmClient = HelmClient.findClient(cmdClient());
+        }
+        return helmClient;
     }
 
     public KubeCluster cluster() {

--- a/src/test/java/io/strimzi/utils/k8s/cmdClient/BaseCmdKubeClient.java
+++ b/src/test/java/io/strimzi/utils/k8s/cmdClient/BaseCmdKubeClient.java
@@ -85,6 +85,13 @@ public abstract class BaseCmdKubeClient<K extends BaseCmdKubeClient<K>> implemen
         }
     }
 
+    @Override
+    @SuppressWarnings("unchecked")
+    public K deleteByName(String resourceType, String resourceName) {
+        Exec.exec(namespacedCommand(DELETE, resourceType, resourceName));
+        return (K) this;
+    }
+
     private Map<File, ExecResult> execRecursive(String subcommand, File[] files, Comparator<File> cmp) {
         Map<File, ExecResult> execResults = new HashMap<>(25);
         for (File f : files) {

--- a/src/test/java/io/strimzi/utils/k8s/cmdClient/KubeCmdClient.java
+++ b/src/test/java/io/strimzi/utils/k8s/cmdClient/KubeCmdClient.java
@@ -19,11 +19,16 @@ public interface KubeCmdClient<K extends KubeCmdClient<K>> {
 
     KubeCmdClient<K> namespace(String namespace);
 
+    /** Returns namespace for cluster */
+    String namespace();
+
     /** Creates the resources in the given files. */
     K apply(File... files);
 
     /** Deletes the resources in the given files. */
     K delete(File... files);
+
+    K deleteByName(String resourceType, String resourceName);
 
     default K delete(String... files) {
         return delete(asList(files).stream().map(File::new).collect(toList()).toArray(new File[0]));

--- a/src/test/java/io/strimzi/utils/k8s/cmdClient/Kubectl.java
+++ b/src/test/java/io/strimzi/utils/k8s/cmdClient/Kubectl.java
@@ -23,6 +23,11 @@ public class Kubectl extends BaseCmdKubeClient<Kubectl> {
     }
 
     @Override
+    public String namespace() {
+        return namespace;
+    }
+
+    @Override
     public String defaultNamespace() {
         return "default";
     }


### PR DESCRIPTION
This PR adds Helm installation method to the systemtests.

It also refactors the whole deployment of Drain cleaner and adds supporting utils classes and enums.
Also, as part of this, new AZP step is added, so the STs will be run with Helm install type.