### PR TITLE
Update Quarkus before the expected release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,10 +19,10 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     
     <!-- Quarkus -->
-    <quarkus-plugin.version>2.15.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.16.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.15.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.16.0.Final</quarkus.platform.version>
     
     <!-- Other versions - used in Test -->
     <log4j.version>2.17.2</log4j.version>


### PR DESCRIPTION
As we are expecting doing a new release soon, this PR updates the Drain Cleaner to use the latest version of Quarkus and its dependencies.