### PR TITLE
Fix Helm Chart installation in STs

### DIFF
--- a/src/test/java/io/strimzi/utils/deployment/installation/HelmInstallation.java
+++ b/src/test/java/io/strimzi/utils/deployment/installation/HelmInstallation.java
@@ -39,17 +39,17 @@ public class HelmInstallation extends InstallationMethod {
 
         if (Environment.CLEANER_REGISTRY != null) {
             // image registry config
-            values.put("defaultImageRegistry", Environment.CLEANER_REGISTRY);
+            values.put("image.registry", Environment.CLEANER_REGISTRY);
         }
 
         if (Environment.CLEANER_ORG != null) {
             // image repository config
-            values.put("defaultImageRepository", Environment.CLEANER_ORG);
+            values.put("image.repository", Environment.CLEANER_ORG);
         }
 
         if (Environment.CLEANER_TAG != null) {
             // image tags config
-            values.put("defaultImageTag", Environment.CLEANER_TAG);
+            values.put("image.tag", Environment.CLEANER_TAG);
         }
 
         // don't deploy certificate and issuer


### PR DESCRIPTION
This PR fixes the options in the Helm Chart STs used to configure what image should be used during the tests. They seem to be using the old options for configuring the images which are not supported anymore.