### PR TITLE
Fix Azure release pipeline (Helm Chart archive extension extension)

### DIFF
--- a/.azure/release-pipeline.yaml
+++ b/.azure/release-pipeline.yaml
@@ -60,7 +60,7 @@ stages:
             artifact: ReleaseTarGzArchive
           - publish: $(System.DefaultWorkingDirectory)/strimzi-drain-cleaner-${{ parameters.releaseVersion }}.zip
             artifact: ReleaseZipArchive
-          - publish: $(System.DefaultWorkingDirectory)/strimzi-drain-cleaner-helm-3-chart-${{ parameters.releaseVersion }}.zip
+          - publish: $(System.DefaultWorkingDirectory)/strimzi-drain-cleaner-helm-3-chart-${{ parameters.releaseVersion }}.tgz
             artifact: HelmChartArchive
   - stage: containers_publish_with_suffix
     displayName: Publish Containers for ${{ parameters.releaseVersion }}-${{ parameters.releaseSuffix }}


### PR DESCRIPTION
The release pipeline is collecting the Helm Chart artifact. However, it expects it to be a `zip` archive. But it fails because it is a `tgz` archive. This PR fixes the used extension.