### PR TITLE
Update the CI to use Ubuntu 22.04 and use the pre-installed Java

### DIFF
--- a/.azure/release-pipeline.yaml
+++ b/.azure/release-pipeline.yaml
@@ -35,19 +35,17 @@ stages:
         strategy:
           matrix:
             'java-17':
-              image: 'Ubuntu-20.04'
+              image: 'Ubuntu-22.04'
               jdk_version: '17'
-              jdk_path: '/usr/lib/jvm/java-17-openjdk-amd64'
         # Set timeout for jobs
         timeoutInMinutes: 60
         # Base system
         pool:
-          vmImage: 'Ubuntu-20.04'
+          vmImage: 'Ubuntu-22.04'
         # Pipeline steps
         steps:
           - template: 'templates/steps/setup_java.yaml'
             parameters:
-              JDK_PATH: $(jdk_path)
               JDK_VERSION: $(jdk_version)
           - bash: ".azure/scripts/release-artifacts.sh"
             env:

--- a/.azure/templates/jobs/build_container.yaml
+++ b/.azure/templates/jobs/build_container.yaml
@@ -11,7 +11,7 @@ jobs:
     timeoutInMinutes: 60
     # Base system
     pool:
-      vmImage: 'Ubuntu-20.04'
+      vmImage: 'Ubuntu-22.04'
     # Pipeline steps
     steps:
       - template: '../steps/setup_docker.yaml'

--- a/.azure/templates/jobs/build_java.yaml
+++ b/.azure/templates/jobs/build_java.yaml
@@ -5,9 +5,8 @@ jobs:
     strategy:
       matrix:
         'java-17':
-          image: 'Ubuntu-20.04'
+          image: 'Ubuntu-22.04'
           jdk_version: '17'
-          jdk_path: '/usr/lib/jvm/java-17-openjdk-amd64'
     # Set timeout for jobs
     timeoutInMinutes: 60
     # Base system
@@ -23,7 +22,6 @@ jobs:
       - template: "../steps/maven_cache.yaml"
       - template: '../steps/setup_java.yaml'
         parameters:
-          JDK_PATH: $(jdk_path)
           JDK_VERSION: $(jdk_version)
       - bash: ".azure/scripts/java-build.sh"
         displayName: "Build & Test Java"

--- a/.azure/templates/jobs/push_container.yaml
+++ b/.azure/templates/jobs/push_container.yaml
@@ -5,7 +5,7 @@ jobs:
     timeoutInMinutes: 60
     # Base system
     pool:
-      vmImage: 'Ubuntu-20.04'
+      vmImage: 'Ubuntu-22.04'
     # Pipeline steps
     steps:
       - template: '../steps/setup_docker.yaml'

--- a/.azure/templates/jobs/run_systemtests.yaml
+++ b/.azure/templates/jobs/run_systemtests.yaml
@@ -6,16 +6,14 @@ jobs:
         ${{ each arch in parameters.architectures }}:
           ${{ arch }}:
             arch: ${{ arch }}
-            image: 'Ubuntu-20.04'
+            image: 'Ubuntu-22.04'
             jdk_version: '17'
-            jdk_path: '/usr/lib/jvm/java-17-openjdk-amd64'
     pool:
       vmImage: $(image)
     timeoutInMinutes: 20
     steps:
       - template: '../steps/setup_java.yaml'
         parameters:
-          JDK_PATH: $(jdk_path)
           JDK_VERSION: $(jdk_version)
       - template: '../steps/setup_docker.yaml'
       - template: '../steps/setup_minikube.yaml'

--- a/.azure/templates/steps/setup_java.yaml
+++ b/.azure/templates/steps/setup_java.yaml
@@ -1,29 +1,11 @@
-# Step to set up JAVA on the agent
-# We use openjdk-X, where X is Java version. Images are based on Java 17
+# Step to configure JAVA on the agent
 parameters:
-  - name: JDK_PATH
-    default: '/usr/lib/jvm/java-17-openjdk-amd64'
   - name: JDK_VERSION
     default: '17'
 steps:
-
-- bash: |
-    sudo apt-get update
-  displayName: 'Update package list'
-
-- bash: |
-    sudo apt-get install openjdk-17-jdk
-  displayName: 'Install openjdk17'
-  condition: eq(variables['JDK_VERSION'], '17')
-
-- bash: |
-    echo "##vso[task.setvariable variable=JAVA_VERSION_BUILD]17"
-    echo "##vso[task.setvariable variable=JAVA_VERSION]17"
-  displayName: 'Setup JAVA_VERSION=17'
-  condition: eq(variables['JDK_VERSION'], '17')
-
-- bash: |
-    echo "##vso[task.setvariable variable=JAVA_HOME]$(JDK_PATH)"
-    echo "##vso[task.setvariable variable=JAVA_HOME__X64]$(JDK_PATH)"
-    echo "##vso[task.setvariable variable=PATH]$(jdk_path)/bin:$(PATH)"
-  displayName: 'Setup JAVA_HOME'
+  - task: JavaToolInstaller@0
+    inputs:
+      versionSpec: $(JDK_VERSION)
+      jdkArchitectureOption: 'x64'
+      jdkSourceOption: 'PreInstalled'
+    displayName: 'Configure Java'


### PR DESCRIPTION
This PR updates the VM image used by the CI pipelines to Ubuntu 22.04. It also updates the way Java is installed / configured to use the pre-installed Java instead of installing our own. That should speed up the pipelines.