### PR TITLE
Add emtpyDir volume for vertx cache

### DIFF
--- a/helm-charts/helm3/strimzi-drain-cleaner/templates/060-Deployment.yaml
+++ b/helm-charts/helm3/strimzi-drain-cleaner/templates/060-Deployment.yaml
@@ -39,6 +39,8 @@ spec:
             - name: webhook-certificates
               mountPath: "/etc/webhook-certificates"
               readOnly: true
+            - name: vertx-cache
+              mountPath: "/tmp/vertx-cache"
           livenessProbe:
             httpGet:
               path: /health
@@ -75,5 +77,7 @@ spec:
         - name: webhook-certificates
           secret:
             secretName: strimzi-drain-cleaner
+        - name: vertx-cache
+          emptyDir: {}
   strategy:
     type: RollingUpdate

--- a/install/certmanager/060-Deployment.yaml
+++ b/install/certmanager/060-Deployment.yaml
@@ -44,6 +44,8 @@ spec:
           volumeMounts:
             - name: webhook-certificates
               mountPath: "/etc/webhook-certificates"
+            - name: vertx-cache
+              mountPath: "/tmp/vertx-cache"
               readOnly: true
           livenessProbe:
             httpGet:
@@ -61,5 +63,7 @@ spec:
         - name: webhook-certificates
           secret:
             secretName: strimzi-drain-cleaner
+        - name: vertx-cache
+          emptyDir: {}
   strategy:
     type: RollingUpdate

--- a/install/kubernetes/060-Deployment.yaml
+++ b/install/kubernetes/060-Deployment.yaml
@@ -45,6 +45,8 @@ spec:
             - name: webhook-certificates
               mountPath: "/etc/webhook-certificates"
               readOnly: true
+            - name: vertx-cache
+              mountPath: "/tmp/vertx-cache"
           livenessProbe:
             httpGet:
               path: /health
@@ -61,5 +63,7 @@ spec:
         - name: webhook-certificates
           secret:
             secretName: strimzi-drain-cleaner
+        - name: vertx-cache
+          emptyDir: {}
   strategy:
     type: RollingUpdate

--- a/install/openshift/060-Deployment.yaml
+++ b/install/openshift/060-Deployment.yaml
@@ -45,6 +45,8 @@ spec:
             - name: webhook-certificates
               mountPath: "/etc/webhook-certificates"
               readOnly: true
+            - name: vertx-cache
+              mountPath: "/tmp/vertx-cache"
           livenessProbe:
             httpGet:
               path: /health
@@ -61,5 +63,7 @@ spec:
         - name: webhook-certificates
           secret:
             secretName: strimzi-drain-cleaner
+        - name: vertx-cache
+          emptyDir: {}
   strategy:
     type: RollingUpdate

--- a/packaging/helm-charts/helm3/strimzi-drain-cleaner/templates/060-Deployment.yaml
+++ b/packaging/helm-charts/helm3/strimzi-drain-cleaner/templates/060-Deployment.yaml
@@ -39,6 +39,8 @@ spec:
             - name: webhook-certificates
               mountPath: "/etc/webhook-certificates"
               readOnly: true
+            - name: vertx-cache
+              mountPath: "/tmp/vertx-cache"
           livenessProbe:
             httpGet:
               path: /health
@@ -75,5 +77,7 @@ spec:
         - name: webhook-certificates
           secret:
             secretName: strimzi-drain-cleaner
+        - name: vertx-cache
+          emptyDir: {}
   strategy:
     type: RollingUpdate

--- a/packaging/install/certmanager/060-Deployment.yaml
+++ b/packaging/install/certmanager/060-Deployment.yaml
@@ -45,6 +45,8 @@ spec:
             - name: webhook-certificates
               mountPath: "/etc/webhook-certificates"
               readOnly: true
+            - name: vertx-cache
+              mountPath: "/tmp/vertx-cache"
           livenessProbe:
             httpGet:
               path: /health
@@ -61,5 +63,7 @@ spec:
         - name: webhook-certificates
           secret:
             secretName: strimzi-drain-cleaner
+        - name: vertx-cache
+          emptyDir: {}
   strategy:
     type: RollingUpdate

--- a/packaging/install/kubernetes/060-Deployment.yaml
+++ b/packaging/install/kubernetes/060-Deployment.yaml
@@ -45,6 +45,8 @@ spec:
             - name: webhook-certificates
               mountPath: "/etc/webhook-certificates"
               readOnly: true
+            - name: vertx-cache
+              mountPath: "/tmp/vertx-cache"
           livenessProbe:
             httpGet:
               path: /health
@@ -61,5 +63,7 @@ spec:
         - name: webhook-certificates
           secret:
             secretName: strimzi-drain-cleaner
+        - name: vertx-cache
+          emptyDir: {}
   strategy:
     type: RollingUpdate

--- a/packaging/install/openshift/060-Deployment.yaml
+++ b/packaging/install/openshift/060-Deployment.yaml
@@ -45,6 +45,8 @@ spec:
             - name: webhook-certificates
               mountPath: "/etc/webhook-certificates"
               readOnly: true
+            - name: vertx-cache
+              mountPath: "/tmp/vertx-cache"
           livenessProbe:
             httpGet:
               path: /health
@@ -61,5 +63,7 @@ spec:
         - name: webhook-certificates
           secret:
             secretName: strimzi-drain-cleaner
+        - name: vertx-cache
+          emptyDir: {}
   strategy:
     type: RollingUpdate


### PR DESCRIPTION
Should fix #76. It adds an emptyDir volume on the /tmp/vertx-cache path in the container so it can write to the folder even when readOnlyRootFilesystem is turned on for the container. 