### PR TITLE
feat: Add support for extra namespace labels

### DIFF
--- a/packaging/helm-charts/helm3/strimzi-drain-cleaner/templates/000-Namespace.yaml
+++ b/packaging/helm-charts/helm3/strimzi-drain-cleaner/templates/000-Namespace.yaml
@@ -5,4 +5,7 @@ metadata:
   name: {{ .Values.namespace.name }}
   labels:
     {{- include "strimzi-drain-cleaner.labels" . | nindent 4 }}
+    {{- with .Values.namespace.extraLabels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 {{- end }}

--- a/packaging/helm-charts/helm3/strimzi-drain-cleaner/values.yaml
+++ b/packaging/helm-charts/helm3/strimzi-drain-cleaner/values.yaml
@@ -34,6 +34,8 @@ secret:
 namespace:
   create: true
   name: strimzi-drain-cleaner
+  # Extra lables to add to the namespace
+  extraLabels: {}
 
 args:
   - /opt/strimzi/bin/drain_cleaner_run.sh


### PR DESCRIPTION
## What?

Here we are adding a value key that can take an object and directly inject this into the labels of the namespace directly.

## Why?

This is useful now that in k8s 1.25+ to be able to add Pod Security Standards labels to assist the Pod Security Admonition controller with applying the right policies.

## Example Usage

```yaml
# values.yaml
namespace:
  create: true
  name: strimzi-drain-cleaner
  extraLabels:
    pod-security.kubernetes.io/enforce: baseline
    pod-security.kubernetes.io/warn: baseline
```