### PR TITLE
Update Netty and Quarkus to avoid CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,10 +19,13 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     
     <!-- Quarkus -->
-    <quarkus-plugin.version>2.16.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>3.1.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.16.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>3.1.2.Final</quarkus.platform.version>
+
+    <!-- Netty version used for override -->
+    <netty.version>4.1.94.Final</netty.version>
     
     <!-- Other versions - used in Test -->
     <log4j.version>2.17.2</log4j.version>
@@ -31,6 +34,14 @@
   </properties>
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <!-- Overrides Netty version due to CVEs in Netty 4.1.93.Final -->
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>${netty.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>${quarkus.platform.group-id}</groupId>
         <artifactId>${quarkus.platform.artifact-id}</artifactId>

--- a/src/main/java/io/strimzi/CertificateWatch.java
+++ b/src/main/java/io/strimzi/CertificateWatch.java
@@ -14,9 +14,9 @@ import org.eclipse.microprofile.config.ConfigProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.event.Observes;
-import javax.inject.Inject;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;

--- a/src/main/java/io/strimzi/HealthCheck.java
+++ b/src/main/java/io/strimzi/HealthCheck.java
@@ -4,10 +4,10 @@
  */
 package io.strimzi;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 import org.jboss.logging.Logger;
 

--- a/src/main/java/io/strimzi/ValidatingWebhook.java
+++ b/src/main/java/io/strimzi/ValidatingWebhook.java
@@ -15,12 +15,12 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.inject.Inject;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Pattern;


### PR DESCRIPTION
This PR updates Quarkus and Netty to address CVEs in the Drain Cleaner code. It updates Quarkus to 3.1.2 and overrides Netty to 4.1.94.