### PR TITLE
Fix minor issues in the release pipeline

### DIFF
--- a/.azure/release-pipeline.yaml
+++ b/.azure/release-pipeline.yaml
@@ -44,7 +44,7 @@ stages:
           vmImage: 'Ubuntu-22.04'
         # Pipeline steps
         steps:
-          - template: '../steps/prerequisites/install_java.yaml'
+          - template: 'templates/steps/prerequisites/install_java.yaml'
             parameters:
               JDK_VERSION: $(jdk_version)
           - bash: ".azure/scripts/release-artifacts.sh"
@@ -95,7 +95,7 @@ stages:
   - stage: helm_as_oci_publish
     displayName: Publish Helm Chart as OCI artifact
     dependsOn:
-      - prepare_release_artifacts
+      - release_artifacts
     condition: and(succeeded(), startsWith(variables['build.sourceBranch'], 'refs/heads/release-'))
     jobs:
       - template: 'templates/jobs/push_helm_chart.yaml'

--- a/.azure/templates/jobs/push_helm_chart.yaml
+++ b/.azure/templates/jobs/push_helm_chart.yaml
@@ -15,14 +15,12 @@ jobs:
       - task: DownloadPipelineArtifact@2
         inputs:
           source: '${{ parameters.artifactSource }}'
-          artifact: ReleaseArchives
+          artifact: HelmChartArchive
           path: $(System.DefaultWorkingDirectory)/
           project: '${{ parameters.artifactProject }}'
           pipeline: '${{ parameters.artifactPipeline }}'
           runVersion: '${{ parameters.artifactRunVersion }}'
           runId: '${{ parameters.artifactRunId }}'
-      - bash: tar -xvf release.tar
-        displayName: "Untar the release artifacts"
 
       # Login Helm to the OCI Registry
       - bash: "helm registry login -u $DOCKER_USER -p $DOCKER_PASS $DOCKER_REGISTRY"


### PR DESCRIPTION
This PR fixes some minor issues in the release pipeline discovered during the 0.5.0-rc1 release:
* Wrong path to the Java installation step
* Wrong unpacking of the Helm Chart artifact