### PR TITLE
Add Drain Cleaner 0.5.0 release to `install/` and `helm-charts/` directories

### DIFF
--- a/helm-charts/helm3/strimzi-drain-cleaner/Chart.yaml
+++ b/helm-charts/helm3/strimzi-drain-cleaner/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.4.2
+appVersion: 0.5.0
 description: Utility which helps with moving the Apache Kafka pods deployed by Strimzi
   from Kubernetes nodes which are being drained.
 home: https://strimzi.io/
@@ -7,4 +7,4 @@ name: strimzi-drain-cleaner
 sources:
 - https://github.com/strimzi/drain-cleaner
 type: application
-version: 0.4.2
+version: 0.5.0

--- a/helm-charts/helm3/strimzi-drain-cleaner/README.md
+++ b/helm-charts/helm3/strimzi-drain-cleaner/README.md
@@ -138,7 +138,7 @@ For a full list of supported options, check the [`values.yaml` file](./values.ya
 | `image.registry`        | Override default Drain Cleaner image registry            | `quay.io`       |
 | `image.repository`      | Override default Drain Cleaner image repository          | `strimzi`       |
 | `image.name`            | Drain Cleaner image name                                 | `drain-cleaner` |
-| `image.tag`             | Override default Drain Cleaner image tag                 | `0.4.2`        |
+| `image.tag`             | Override default Drain Cleaner image tag                 | `0.5.0`        |
 | `image.imagePullPolicy` | Image pull policy for all pods deployed by Drain Cleaner | `nil`           |
 | `resources`             | Configures resources for the Drain Cleaner Pod           | `[]`            |
 | `tolerations`           | Add tolerations to Drain Cleaner Pod                     | `[]`            |

--- a/helm-charts/helm3/strimzi-drain-cleaner/templates/000-Namespace.yaml
+++ b/helm-charts/helm3/strimzi-drain-cleaner/templates/000-Namespace.yaml
@@ -5,4 +5,7 @@ metadata:
   name: {{ .Values.namespace.name }}
   labels:
     {{- include "strimzi-drain-cleaner.labels" . | nindent 4 }}
+    {{- with .Values.namespace.extraLabels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 {{- end }}

--- a/helm-charts/helm3/strimzi-drain-cleaner/values.yaml
+++ b/helm-charts/helm3/strimzi-drain-cleaner/values.yaml
@@ -9,7 +9,7 @@ image:
   registry: quay.io
   repository: strimzi
   name: drain-cleaner
-  tag: 0.4.2
+  tag: 0.5.0
   pullPolicy: ""
 
 serviceAccount:
@@ -34,6 +34,8 @@ secret:
 namespace:
   create: true
   name: strimzi-drain-cleaner
+  # Extra lables to add to the namespace
+  extraLabels: {}
 
 args:
   - /opt/strimzi/bin/drain_cleaner_run.sh

--- a/install/certmanager/060-Deployment.yaml
+++ b/install/certmanager/060-Deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: strimzi-drain-cleaner
       containers:
         - name: strimzi-drain-cleaner
-          image: quay.io/strimzi/drain-cleaner:0.4.2
+          image: quay.io/strimzi/drain-cleaner:0.5.0
           ports:
             - containerPort: 8080
               name: http

--- a/install/kubernetes/060-Deployment.yaml
+++ b/install/kubernetes/060-Deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: strimzi-drain-cleaner
       containers:
         - name: strimzi-drain-cleaner
-          image: quay.io/strimzi/drain-cleaner:0.4.2
+          image: quay.io/strimzi/drain-cleaner:0.5.0
           ports:
             - containerPort: 8080
               name: http

--- a/install/openshift/060-Deployment.yaml
+++ b/install/openshift/060-Deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: strimzi-drain-cleaner
       containers:
         - name: strimzi-drain-cleaner
-          image: quay.io/strimzi/drain-cleaner:0.4.2
+          image: quay.io/strimzi/drain-cleaner:0.5.0
           ports:
             - containerPort: 8080
               name: http


### PR DESCRIPTION
This PR adds the new Drain Cleaner 0.5.0 release to `install/` and `helm-charts/` directories.