### PR TITLE
Add ArtifactHub badge and use OCI repository in the Helm Chart README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![GitHub release](https://img.shields.io/github/release/strimzi/drain-cleaner.svg)](https://github.com/strimzi/drain-cleaner/releases/latest)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
 [![Twitter Follow](https://img.shields.io/twitter/follow/strimziio?style=social)](https://twitter.com/strimziio)
+[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/strimzi-drain-cleaner)](https://artifacthub.io/packages/search?repo=strimzi-drain-cleaner)
 
 # Strimzi Drain Cleaner
 

--- a/packaging/helm-charts/helm3/strimzi-drain-cleaner/Chart.yaml
+++ b/packaging/helm-charts/helm3/strimzi-drain-cleaner/Chart.yaml
@@ -2,6 +2,7 @@ apiVersion: v2
 appVersion: 1.0.0
 description: Utility which helps with moving the Apache Kafka pods deployed by Strimzi from Kubernetes nodes which are being drained.
 name: strimzi-drain-cleaner
+icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/main/documentation/logo/strimzi_logo.png
 type: application
 version: 0.1.0
 home: https://strimzi.io/

--- a/packaging/helm-charts/helm3/strimzi-drain-cleaner/README.md
+++ b/packaging/helm-charts/helm3/strimzi-drain-cleaner/README.md
@@ -101,16 +101,10 @@ Strimzi is licensed under the [Apache License](https://github.com/strimzi/drain-
 
 ## Installing the Chart
 
-Add the Strimzi Helm Chart repository:
+To install the chart with the release name `my-strimzi-drain-cleaner`:
 
 ```bash
-$ helm repo add strimzi https://strimzi.io/charts/
-```
-
-To install the chart with the release name `my-release`:
-
-```bash
-$ helm install drain-cleaner strimzi/strimzi-drain-cleaner
+$ helm install my-strimzi-drain-cleaner oci://quay.io/strimzi-helm/strimzi-drain-cleaner
 ```
 
 The command deploys the Strimzi Drain Cleaner on the Kubernetes cluster with the default configuration.
@@ -119,10 +113,10 @@ The [configuration](#configuration) section lists the parameters that can be con
 
 ## Uninstalling the Chart
 
-To uninstall/delete the `drain-cleaner` deployment:
+To uninstall/delete the `my-strimzi-drain-cleaner` deployment:
 
 ```bash
-$ helm delete drain-cleaner
+$ helm delete my-strimzi-drain-cleaner
 ```
 
 The command removes all the Kubernetes components associated with the Drain Cleaner utility and deletes the release.
@@ -148,5 +142,5 @@ For a full list of supported options, check the [`values.yaml` file](./values.ya
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```bash
-$ helm install --name drain-cleaner --set replicas=2 strimzi/strimzi-drain-cleaner
+$ helm install my-strimzi-drain-cleaner --set replicaCount=2 oci://quay.io/strimzi-helm/strimzi-drain-cleaner
 ```


### PR DESCRIPTION
This PR adds an ArtifactHub badge to the main README.md file. It also updates the Helm Chart README file to use the OCI repository instead of the old website repository. It also adds an icon to the Helm Chart specification.