### PR TITLE
Update Quarkus to 3.2.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,14 +19,11 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     
     <!-- Quarkus -->
-    <quarkus-plugin.version>3.1.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>3.2.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.1.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>3.2.0.Final</quarkus.platform.version>
 
-    <!-- Netty version used for override -->
-    <netty.version>4.1.94.Final</netty.version>
-    
     <!-- Other versions - used in Test -->
     <log4j.version>2.17.2</log4j.version>
     <jayway-jsonpath.version>2.6.0</jayway-jsonpath.version>
@@ -34,14 +31,6 @@
   </properties>
   <dependencyManagement>
     <dependencies>
-      <dependency>
-        <!-- Overrides Netty version due to CVEs in Netty 4.1.93.Final -->
-        <groupId>io.netty</groupId>
-        <artifactId>netty-bom</artifactId>
-        <version>${netty.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
       <dependency>
         <groupId>${quarkus.platform.group-id}</groupId>
         <artifactId>${quarkus.platform.artifact-id}</artifactId>


### PR DESCRIPTION
This PR updates Qurkus to 3.2.0.Final - which is the new Quarkus LTS release.