### PR TITLE
Update Quarkus and other dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,15 +19,15 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     
     <!-- Quarkus -->
-    <quarkus-plugin.version>3.2.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>3.2.6.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.2.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>3.2.6.Final</quarkus.platform.version>
 
     <!-- Other versions - used in Test -->
     <log4j.version>2.17.2</log4j.version>
-    <jayway-jsonpath.version>2.6.0</jayway-jsonpath.version>
-    <bouncycastle.version>1.68</bouncycastle.version>
+    <jayway-jsonpath.version>2.8.0</jayway-jsonpath.version>
+    <bouncycastle.version>1.76</bouncycastle.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -97,13 +97,13 @@
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-jdk15on</artifactId>
+      <artifactId>bcpkix-jdk18on</artifactId>
       <version>${bouncycastle.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk15on</artifactId>
+      <artifactId>bcprov-jdk18on</artifactId>
       <version>${bouncycastle.version}</version>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
This PR updates Quarkus to 3.2.6 that is the latest LTS version. It also updates some other dependencies - Json-path and BouncyCastle that are used only in tests but seem to be reporting some CVEs.