### PR TITLE
Add Drain Cleaner 1.0.0 release to the main branch

### DIFF
--- a/.azure/templates/jobs/push_container.yaml
+++ b/.azure/templates/jobs/push_container.yaml
@@ -84,7 +84,7 @@ jobs:
       - bash: tar -z -C ./sbom/ -cvpf sbom.tar.gz ./
         displayName: "Tar the SBOM files"
       - publish: $(System.DefaultWorkingDirectory)/sbom.tar.gz
-        artifact: SBOMs
+        artifact: SBOMs-${{ parameters.dockerTag }}
         displayName: "Publish the SBOM files"
       # push the SBOMs to container registry only for releases
       - ${{ each arch in parameters.architectures }}:

--- a/helm-charts/helm3/strimzi-drain-cleaner/Chart.yaml
+++ b/helm-charts/helm3/strimzi-drain-cleaner/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v2
-appVersion: 0.5.0
-description: Utility which helps with moving the Apache Kafka pods deployed by Strimzi
-  from Kubernetes nodes which are being drained.
-home: https://strimzi.io/
+appVersion: 1.0.0
+description: Utility which helps with moving the Apache Kafka pods deployed by Strimzi from Kubernetes nodes which are being drained.
 name: strimzi-drain-cleaner
+icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/main/documentation/logo/strimzi_logo.png
+type: application
+version: 1.0.0
+home: https://strimzi.io/
 sources:
 - https://github.com/strimzi/drain-cleaner
-type: application
-version: 0.5.0

--- a/helm-charts/helm3/strimzi-drain-cleaner/README.md
+++ b/helm-charts/helm3/strimzi-drain-cleaner/README.md
@@ -101,16 +101,10 @@ Strimzi is licensed under the [Apache License](https://github.com/strimzi/drain-
 
 ## Installing the Chart
 
-Add the Strimzi Helm Chart repository:
+To install the chart with the release name `my-strimzi-drain-cleaner`:
 
 ```bash
-$ helm repo add strimzi https://strimzi.io/charts/
-```
-
-To install the chart with the release name `my-release`:
-
-```bash
-$ helm install drain-cleaner strimzi/strimzi-drain-cleaner
+$ helm install my-strimzi-drain-cleaner oci://quay.io/strimzi-helm/strimzi-drain-cleaner
 ```
 
 The command deploys the Strimzi Drain Cleaner on the Kubernetes cluster with the default configuration.
@@ -119,10 +113,10 @@ The [configuration](#configuration) section lists the parameters that can be con
 
 ## Uninstalling the Chart
 
-To uninstall/delete the `drain-cleaner` deployment:
+To uninstall/delete the `my-strimzi-drain-cleaner` deployment:
 
 ```bash
-$ helm delete drain-cleaner
+$ helm delete my-strimzi-drain-cleaner
 ```
 
 The command removes all the Kubernetes components associated with the Drain Cleaner utility and deletes the release.
@@ -138,7 +132,7 @@ For a full list of supported options, check the [`values.yaml` file](./values.ya
 | `image.registry`        | Override default Drain Cleaner image registry            | `quay.io`       |
 | `image.repository`      | Override default Drain Cleaner image repository          | `strimzi`       |
 | `image.name`            | Drain Cleaner image name                                 | `drain-cleaner` |
-| `image.tag`             | Override default Drain Cleaner image tag                 | `0.5.0`        |
+| `image.tag`             | Override default Drain Cleaner image tag                 | `1.0.0`        |
 | `image.imagePullPolicy` | Image pull policy for all pods deployed by Drain Cleaner | `nil`           |
 | `resources`             | Configures resources for the Drain Cleaner Pod           | `[]`            |
 | `tolerations`           | Add tolerations to Drain Cleaner Pod                     | `[]`            |
@@ -148,5 +142,5 @@ For a full list of supported options, check the [`values.yaml` file](./values.ya
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```bash
-$ helm install --name drain-cleaner --set replicas=2 strimzi/strimzi-drain-cleaner
+$ helm install my-strimzi-drain-cleaner --set replicaCount=2 oci://quay.io/strimzi-helm/strimzi-drain-cleaner
 ```

--- a/helm-charts/helm3/strimzi-drain-cleaner/values.yaml
+++ b/helm-charts/helm3/strimzi-drain-cleaner/values.yaml
@@ -9,7 +9,7 @@ image:
   registry: quay.io
   repository: strimzi
   name: drain-cleaner
-  tag: 0.5.0
+  tag: 1.0.0
   pullPolicy: ""
 
 serviceAccount:

--- a/install/certmanager/060-Deployment.yaml
+++ b/install/certmanager/060-Deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: strimzi-drain-cleaner
       containers:
         - name: strimzi-drain-cleaner
-          image: quay.io/strimzi/drain-cleaner:0.5.0
+          image: quay.io/strimzi/drain-cleaner:1.0.0
           ports:
             - containerPort: 8080
               name: http

--- a/install/kubernetes/060-Deployment.yaml
+++ b/install/kubernetes/060-Deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: strimzi-drain-cleaner
       containers:
         - name: strimzi-drain-cleaner
-          image: quay.io/strimzi/drain-cleaner:0.5.0
+          image: quay.io/strimzi/drain-cleaner:1.0.0
           ports:
             - containerPort: 8080
               name: http

--- a/install/openshift/060-Deployment.yaml
+++ b/install/openshift/060-Deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: strimzi-drain-cleaner
       containers:
         - name: strimzi-drain-cleaner
-          image: quay.io/strimzi/drain-cleaner:0.5.0
+          image: quay.io/strimzi/drain-cleaner:1.0.0
           ports:
             - containerPort: 8080
               name: http


### PR DESCRIPTION
This PR adds the Drain Cleaner 1.0.0 release to the main branch of the Drain Cleaner repo. It also does a minor fix to the publishing of the SBOM archive in the release pipeline that was discovered during the release.