### PR TITLE
feat: helm-chart: allow specifying imagePullSecrets

### DIFF
--- a/packaging/helm-charts/helm3/strimzi-drain-cleaner/Chart.yaml
+++ b/packaging/helm-charts/helm3/strimzi-drain-cleaner/Chart.yaml
@@ -4,7 +4,7 @@ description: Utility which helps with moving the Apache Kafka pods deployed by S
 name: strimzi-drain-cleaner
 icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/main/documentation/logo/strimzi_logo.png
 type: application
-version: 0.1.0
+version: 0.2.0
 home: https://strimzi.io/
 sources:
 - https://github.com/strimzi/drain-cleaner

--- a/packaging/helm-charts/helm3/strimzi-drain-cleaner/README.md
+++ b/packaging/helm-charts/helm3/strimzi-drain-cleaner/README.md
@@ -126,18 +126,19 @@ The command removes all the Kubernetes components associated with the Drain Clea
 The following table lists some available configurable parameters of the Strimzi chart and their default values.
 For a full list of supported options, check the [`values.yaml` file](./values.yaml).
 
-| Parameter               | Description                                              | Default         |
-|-------------------------|----------------------------------------------------------|-----------------|
-| `replicaCount`          | Number of replicas of the Drain Cleaner webhook          | 1               |
-| `image.registry`        | Override default Drain Cleaner image registry            | `quay.io`       |
-| `image.repository`      | Override default Drain Cleaner image repository          | `strimzi`       |
-| `image.name`            | Drain Cleaner image name                                 | `drain-cleaner` |
-| `image.tag`             | Override default Drain Cleaner image tag                 | `latest`        |
-| `image.imagePullPolicy` | Image pull policy for all pods deployed by Drain Cleaner | `nil`           |
-| `resources`             | Configures resources for the Drain Cleaner Pod           | `[]`            |
-| `tolerations`           | Add tolerations to Drain Cleaner Pod                     | `[]`            |
-| `affinity`              | Add affinities to Drain Cleaner Pod                      | `{}`            |
-| `nodeSelector`          | Add a node selector to Drain Cleaner Pod                 | `{}`            |
+| Parameter                | Description                                              | Default         |
+|--------------------------|----------------------------------------------------------|-----------------|
+| `replicaCount`           | Number of replicas of the Drain Cleaner webhook          | 1               |
+| `image.registry`         | Override default Drain Cleaner image registry            | `quay.io`       |
+| `image.repository`       | Override default Drain Cleaner image repository          | `strimzi`       |
+| `image.name`             | Drain Cleaner image name                                 | `drain-cleaner` |
+| `image.tag`              | Override default Drain Cleaner image tag                 | `latest`        |
+| `image.imagePullPolicy`  | Image pull policy for all pods deployed by Drain Cleaner | `nil`           |
+| `image.imagePullSecrets` | List of Docker registry pull secrets                     | `[]`            |
+| `resources`              | Configures resources for the Drain Cleaner Pod           | `[]`            |
+| `tolerations`            | Add tolerations to Drain Cleaner Pod                     | `[]`            |
+| `affinity`               | Add affinities to Drain Cleaner Pod                      | `{}`            |
+| `nodeSelector`           | Add a node selector to Drain Cleaner Pod                 | `{}`            |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/packaging/helm-charts/helm3/strimzi-drain-cleaner/templates/060-Deployment.yaml
+++ b/packaging/helm-charts/helm3/strimzi-drain-cleaner/templates/060-Deployment.yaml
@@ -22,6 +22,12 @@ spec:
         {{- end }}
     spec:
       serviceAccountName: {{ include "strimzi-drain-cleaner.serviceAccountName" . }}
+      {{- if .Values.image.imagePullSecrets }}
+      imagePullSecrets:
+        {{- with .Values.image.imagePullSecrets }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
       containers:
         - name: strimzi-drain-cleaner
           image: {{ .Values.image.registry }}/{{ .Values.image.repository}}/{{ .Values.image.name }}:{{ .Values.image.tag }}

--- a/packaging/helm-charts/helm3/strimzi-drain-cleaner/values.yaml
+++ b/packaging/helm-charts/helm3/strimzi-drain-cleaner/values.yaml
@@ -11,6 +11,7 @@ image:
   name: drain-cleaner
   tag: latest
   pullPolicy: ""
+  imagePullSecrets: []
 
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
Tentative example implementation of allowing specifying the imagePullSecret for use with Strimzi Drain Cleaner
An example use case is usage of private container registries as mandated by policy for image scanning purposes, as well as resiliency against network failures and/or unavailability of quay.io

( please do note that we have doubts on the way the chart's versioning is being handled, please advise 🙏 )