### PR TITLE
Update Quarkus to 3.2.9 to address CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,10 +19,10 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     
     <!-- Quarkus -->
-    <quarkus-plugin.version>3.2.6.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>3.2.9.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.2.6.Final</quarkus.platform.version>
+    <quarkus.platform.version>3.2.9.Final</quarkus.platform.version>
 
     <!-- Other versions - used in Test -->
     <log4j.version>2.17.2</log4j.version>


### PR DESCRIPTION
This PR updates the Quarkus version used by Drain Cleaner to 3.2.9.Final to address some CVEs -> especially the Netty CVE that is reported as _High_ in image scans.