### PR TITLE
Remove Jayway Json Path dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,6 @@
 
     <!-- Other versions - used in Test -->
     <log4j.version>2.17.2</log4j.version>
-    <jayway-jsonpath.version>2.8.0</jayway-jsonpath.version>
     <bouncycastle.version>1.76</bouncycastle.version>
   </properties>
   <dependencyManagement>
@@ -71,12 +70,6 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-resteasy-jackson</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.jayway.jsonpath</groupId>
-      <artifactId>json-path</artifactId>
-      <version>${jayway-jsonpath.version}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jboss.logmanager</groupId>


### PR DESCRIPTION
This PR removes the dependency on the Jayway Json Path that does not seem to be used for anything.