### PR TITLE
Update Quarkus to 3.2.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,14 +19,14 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     
     <!-- Quarkus -->
-    <quarkus-plugin.version>3.2.9.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>3.2.10.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.2.9.Final</quarkus.platform.version>
+    <quarkus.platform.version>3.2.10.Final</quarkus.platform.version>
 
     <!-- Other versions - used in Test -->
     <log4j.version>2.17.2</log4j.version>
-    <bouncycastle.version>1.76</bouncycastle.version>
+    <bouncycastle.version>1.77</bouncycastle.version>
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
This PR updates the Quarkus dependency to the latest patch release of the LTS stream 3.2.10. It also updates BouncyCastle dependency. these address several CVEs and bugfixes.