### PR TITLE
Increase the system test timeout in Azure CI

### DIFF
--- a/.azure/templates/jobs/run_systemtests.yaml
+++ b/.azure/templates/jobs/run_systemtests.yaml
@@ -10,7 +10,7 @@ jobs:
             jdk_version: '17'
     pool:
       vmImage: $(image)
-    timeoutInMinutes: 20
+    timeoutInMinutes: 30
     steps:
       - template: '../steps/prerequisites/install_java.yaml'
         parameters:


### PR DESCRIPTION
As we add more system tests, it happens sometimes that the ST job in the Azure CI runs over the 20 minute time limit. Especially when for example Minikube download takes too long. This PR increases the timeout to 30 minutes.