### PR TITLE
Update `commons-compress` dependency due to CVE-2024-26308

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,9 @@
     <!-- Other versions - used in Test -->
     <log4j.version>2.17.2</log4j.version>
     <bouncycastle.version>1.77</bouncycastle.version>
+
+    <!-- Used to override Quarkus Kubernetes Client dependency due to CVE-2024-26308 -->
+    <commons-compress.version>1.26.0</commons-compress.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -70,6 +73,12 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-resteasy-jackson</artifactId>
+    </dependency>
+    <!-- Used to override Quarkus Kubernetes Client dependency due to CVE-2024-26308 -->
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+      <version>${commons-compress.version}</version>
     </dependency>
     <dependency>
       <groupId>org.jboss.logmanager</groupId>


### PR DESCRIPTION
Quakus currently has `commons-compress` dependency that has CVE-2024-26308. As we are planning a new release of Drain Cleaner, this PR overrides the dependency to avoid the CVE.