### PR TITLE
Bump version in the main branch to 1.2.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.strimzi</groupId>
   <artifactId>strimzi-drain-cleaner</artifactId>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.0-SNAPSHOT</version>
   <properties>
     <!-- Maven plugins -->
     <compiler-plugin.version>3.10.1</compiler-plugin.version>


### PR DESCRIPTION
As the 1.1.0 release is no underway, we should bump the version in the main branch to 1.2.0-SNAPSHOT.