### PR TITLE
Indent namespaceSelector properly

### DIFF
--- a/packaging/helm-charts/helm3/strimzi-drain-cleaner/templates/070-ValidatingWebhookConfiguration.yaml
+++ b/packaging/helm-charts/helm3/strimzi-drain-cleaner/templates/070-ValidatingWebhookConfiguration.yaml
@@ -26,8 +26,9 @@ webhooks:
       caBundle: {{ .Values.secret.ca_bundle }}
       {{- end }}
     admissionReviewVersions: ["v1"]
-    {{- if (.Values.webhook).namespaceSelector }}
-    namespaceSelector: {{ .Values.webhook.namespaceSelector }}
+    {{- with (.Values.webhook).namespaceSelector }}
+    namespaceSelector: 
+      {{- toYaml . | nindent 6 }}
     {{- end }}
     sideEffects: None
     failurePolicy: Ignore


### PR DESCRIPTION
Hi @scholzj,
I finally got time to test the namespaceSelector changes done here https://github.com/strimzi/drain-cleaner/pull/111 and realised that when I add the following block, 
```yaml
webhook:
  namespaceSelector:
    matchExpressions:
    - key: kubernetes.io/metadata.name
      operator: In
      values:
      - strimzi
```
it is rendered as 🤦🏼 
<img width="998" alt="image" src="https://github.com/strimzi/drain-cleaner/assets/6253803/2dc8cf32-a6e5-4312-af41-91a9058fa013">

Apologies 🙉 

---
This small PR should fix the rendering bug. Tested locally 
<img width="817" alt="image" src="https://github.com/strimzi/drain-cleaner/assets/6253803/7d4189fa-34a1-4747-92e2-b6376b773ed2">

