### PR TITLE
Update Bouncy Castle to address a CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
 
     <!-- Other versions - used in Test -->
     <log4j.version>2.17.2</log4j.version>
-    <bouncycastle.version>1.77</bouncycastle.version>
+    <bouncycastle.version>1.78.1</bouncycastle.version>
 
     <!-- Used to override Quarkus Kubernetes Client dependency due to CVE-2024-26308 -->
     <commons-compress.version>1.26.0</commons-compress.version>
@@ -188,6 +188,12 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk18on</artifactId>
+      <version>${bouncycastle.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcutil-jdk18on</artifactId>
       <version>${bouncycastle.version}</version>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
This PR updates the Bouncy Castle dependency to address a CVE and fixes alignment issue with Quarkus BOM.