### PR TITLE
Move container image to UBI9 base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 ARG JAVA_VERSION=17
 ARG TARGETPLATFORM
 
 USER root
 
 RUN microdnf update \
-    && microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install java-${JAVA_VERSION}-openjdk-headless openssl shadow-utils \
+    && microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y java-${JAVA_VERSION}-openjdk-headless openssl shadow-utils \
     && microdnf clean all
 
 # Set JAVA_HOME env var


### PR DESCRIPTION
This PR follows the https://github.com/strimzi/strimzi-kafka-operator/pull/10126 and updated the Drain Cleaner container image to be based on UBI9 as well.