### PR TITLE
Assume yes when using microdnf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,9 @@ ARG TARGETPLATFORM
 
 USER root
 
-RUN microdnf update \
+RUN microdnf update -y \
     && microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y java-${JAVA_VERSION}-openjdk-headless openssl shadow-utils \
-    && microdnf clean all
+    && microdnf clean all -y
 
 # Set JAVA_HOME env var
 ENV JAVA_HOME /usr/lib/jvm/jre-17


### PR DESCRIPTION
This PR adds the `-y` confirmations to avoid the Docker build to get stuck. This looks like something what changed in the recent UBI9 releases or in the Azure pipelines as it was not needed before.