### PR TITLE
Update Quakrus to 3.8.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,10 +101,10 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     
     <!-- Quarkus -->
-    <quarkus-plugin.version>3.8.3</quarkus-plugin.version>
+    <quarkus-plugin.version>3.8.5</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.8.3</quarkus.platform.version>
+    <quarkus.platform.version>3.8.5</quarkus.platform.version>
 
     <!-- Other versions - used in Test -->
     <log4j.version>2.17.2</log4j.version>


### PR DESCRIPTION
As we received a request for a new release, we should update the dependencies. This PR updates the Quarkus dependency to 3.8.5 (sticking to the last Quarkus LTS release).