### PR TITLE
Add 1.2.0 release to the main branch and bump it to 1.3.0-SNAPSHOT

### DIFF
--- a/.azure/release-pipeline.yaml
+++ b/.azure/release-pipeline.yaml
@@ -95,8 +95,8 @@ stages:
   - stage: helm_as_oci_publish
     displayName: Publish Helm Chart as OCI artifact
     dependsOn:
-      - release_artifacts
-    condition: and(succeeded(), startsWith(variables['build.sourceBranch'], 'refs/heads/release-'))
+      - containers_publish
+    condition: and(in(dependencies.containers_publish.result, 'Succeeded', 'SucceededWithIssues'), startsWith(variables['build.sourceBranch'], 'refs/heads/release-'))
     jobs:
       - template: 'templates/jobs/push_helm_chart.yaml'
         parameters:

--- a/helm-charts/helm3/strimzi-drain-cleaner/README.md
+++ b/helm-charts/helm3/strimzi-drain-cleaner/README.md
@@ -171,7 +171,7 @@ For a full list of supported options, check the [`values.yaml` file](./values.ya
 | `image.registry`         | Override default Drain Cleaner image registry            | `quay.io`       |
 | `image.repository`       | Override default Drain Cleaner image repository          | `strimzi`       |
 | `image.name`             | Drain Cleaner image name                                 | `drain-cleaner` |
-| `image.tag`              | Override default Drain Cleaner image tag                 | `1.1.0`        |
+| `image.tag`              | Override default Drain Cleaner image tag                 | `1.2.0`        |
 | `image.imagePullPolicy`  | Image pull policy for all pods deployed by Drain Cleaner | `nil`           |
 | `image.imagePullSecrets` | List of Docker registry pull secrets                     | `[]`            |
 | `resources`              | Configures resources for the Drain Cleaner Pod           | `[]`            |

--- a/helm-charts/helm3/strimzi-drain-cleaner/templates/060-Deployment.yaml
+++ b/helm-charts/helm3/strimzi-drain-cleaner/templates/060-Deployment.yaml
@@ -20,6 +20,12 @@ spec:
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+      {{- if .Values.podAnnotations }}
+      annotations:
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
     spec:
       serviceAccountName: {{ include "strimzi-drain-cleaner.serviceAccountName" . }}
       {{- if .Values.image.imagePullSecrets }}

--- a/helm-charts/helm3/strimzi-drain-cleaner/templates/070-ValidatingWebhookConfiguration.yaml
+++ b/helm-charts/helm3/strimzi-drain-cleaner/templates/070-ValidatingWebhookConfiguration.yaml
@@ -26,8 +26,9 @@ webhooks:
       caBundle: {{ .Values.secret.ca_bundle }}
       {{- end }}
     admissionReviewVersions: ["v1"]
-    {{- if (.Values.webhook).namespaceSelector }}
-    namespaceSelector: {{ .Values.webhook.namespaceSelector }}
+    {{- with (.Values.webhook).namespaceSelector }}
+    namespaceSelector: 
+      {{- toYaml . | nindent 6 }}
     {{- end }}
     sideEffects: None
     failurePolicy: Ignore

--- a/helm-charts/helm3/strimzi-drain-cleaner/values.yaml
+++ b/helm-charts/helm3/strimzi-drain-cleaner/values.yaml
@@ -9,7 +9,7 @@ image:
   registry: quay.io
   repository: strimzi
   name: drain-cleaner
-  tag: 1.1.0
+  tag: 1.2.0
   pullPolicy: ""
   imagePullSecrets: []
 
@@ -69,6 +69,8 @@ deploymentLabels: {}
 podLabels: {}
   # Specifies optional custom labels for Pod.
   # If you want to add custom labels, add them below and remove curly braces above.
+
+podAnnotations: {}
 
 nodeSelector: {}
 

--- a/install/certmanager/060-Deployment.yaml
+++ b/install/certmanager/060-Deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: strimzi-drain-cleaner
       containers:
         - name: strimzi-drain-cleaner
-          image: quay.io/strimzi/drain-cleaner:1.1.0
+          image: quay.io/strimzi/drain-cleaner:1.2.0
           ports:
             - containerPort: 8080
               name: http

--- a/install/kubernetes/060-Deployment.yaml
+++ b/install/kubernetes/060-Deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: strimzi-drain-cleaner
       containers:
         - name: strimzi-drain-cleaner
-          image: quay.io/strimzi/drain-cleaner:1.1.0
+          image: quay.io/strimzi/drain-cleaner:1.2.0
           ports:
             - containerPort: 8080
               name: http

--- a/install/openshift/060-Deployment.yaml
+++ b/install/openshift/060-Deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: strimzi-drain-cleaner
       containers:
         - name: strimzi-drain-cleaner
-          image: quay.io/strimzi/drain-cleaner:1.1.0
+          image: quay.io/strimzi/drain-cleaner:1.2.0
           ports:
             - containerPort: 8080
               name: http

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>io.strimzi</groupId>
   <artifactId>strimzi-drain-cleaner</artifactId>
-  <version>1.2.0-SNAPSHOT</version>
+  <version>1.3.0-SNAPSHOT</version>
 
   <licenses>
     <license>


### PR DESCRIPTION
This PR adds the new 1.2.0 release to the `main` branch and bumps the version in the main branch to 1.3.0-SNAPSHOT. It also backports some changes to the release pipeline from the 1.2.0 release branch - in particular pushing the Helm Chart OCI image only once the regular container images have been pushed.