### PR TITLE
fix(helm-charts,install): add '.spec.issuerRef.group' and '.spec.issu…

### DIFF
--- a/packaging/helm-charts/helm3/strimzi-drain-cleaner/templates/041-Certificate.yaml
+++ b/packaging/helm-charts/helm3/strimzi-drain-cleaner/templates/041-Certificate.yaml
@@ -14,5 +14,7 @@ spec:
   - {{ include "strimzi-drain-cleaner.name" . }}.{{ .Values.namespace.name }}
   - strimzi-drain-cleaner
   issuerRef:
+    group: cert-manager.io
+    kind: Issuer
     name: strimzi-drain-cleaner
 {{- end }}

--- a/packaging/install/certmanager/041-Certificate.yaml
+++ b/packaging/install/certmanager/041-Certificate.yaml
@@ -13,4 +13,6 @@ spec:
     - strimzi-drain-cleaner.strimzi-drain-cleaner
     - strimzi-drain-cleaner
   issuerRef:
+    group: cert-manager.io
+    kind: Issuer
     name: strimzi-drain-cleaner


### PR DESCRIPTION
…erRef.kind' to Certiticate resource

As 'Issuer' and 'Certificate' resource are deployed via the same Helm chart, the referenced Issuer should be selected to avoid colissions with other issueres/clusterissuers. More related background: https://github.com/cert-manager/approver-policy/pull/523 https://cert-manager.io/docs/usage/certificate/