### PR TITLE
Update Kind version to 0.25.0 in the AZP

### DIFF
--- a/.azure/templates/steps/prerequisites/install_kind.yaml
+++ b/.azure/templates/steps/prerequisites/install_kind.yaml
@@ -3,4 +3,4 @@ steps:
     displayName: "Setup Kind cluster"
     env:
       TEST_KUBECTL_VERSION: latest
-      KIND_VERSION: v0.23.0
+      KIND_VERSION: v0.25.0


### PR DESCRIPTION
In the last PR (#139) I added the Kind cluster to the AZPs. In the comments we decided to update the Kind version to 0.25.0, which was done on the script level, however I forgot to update it also in the AZP file, causing the installation of the 0.23.0.

This PR updates the Kind version to 0.25.0 in the AZPs as well. 