### PR TITLE
fix: add missing default and releasenamespace for Certificate and ValidatingWebhookConfiguration

### DIFF
--- a/packaging/helm-charts/helm3/strimzi-drain-cleaner/templates/041-Certificate.yaml
+++ b/packaging/helm-charts/helm3/strimzi-drain-cleaner/templates/041-Certificate.yaml
@@ -10,8 +10,8 @@ spec:
   secretName: strimzi-drain-cleaner
   commonName: strimzi-drain-cleaner
   dnsNames:
-  - {{ include "strimzi-drain-cleaner.name" . }}.{{ .Values.namespace.name }}.svc
-  - {{ include "strimzi-drain-cleaner.name" . }}.{{ .Values.namespace.name }}
+  - {{ include "strimzi-drain-cleaner.name" . }}.{{default .Release.Namespace .Values.namespace.name }}.svc
+  - {{ include "strimzi-drain-cleaner.name" . }}.{{default .Release.Namespace .Values.namespace.name }}
   - strimzi-drain-cleaner
   issuerRef:
     group: cert-manager.io

--- a/packaging/helm-charts/helm3/strimzi-drain-cleaner/templates/070-ValidatingWebhookConfiguration.yaml
+++ b/packaging/helm-charts/helm3/strimzi-drain-cleaner/templates/070-ValidatingWebhookConfiguration.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "strimzi-drain-cleaner.labels" . | nindent 4 }}
   {{- if .Values.certManager.create }}
   annotations:
-    cert-manager.io/inject-ca-from: {{ .Values.namespace.name }}/strimzi-drain-cleaner
+    cert-manager.io/inject-ca-from: {{default .Release.Namespace .Values.namespace.name }}/strimzi-drain-cleaner
   {{- end }}
 webhooks:
   - name: strimzi-drain-cleaner.strimzi.io


### PR DESCRIPTION
All resources in the Helm Chart are all created in the given `.Values.namespace.name` and defaults to the helm release namespace `.Release.Namespace` if `.Values.namespace.name` is not set.

However the default is not applied on some part of the following resources:

- Certificate
- ValidatingWebhookConfiguration

For instance:

```
$ helm template --namespace release-ns --set namespace.name="" --set certManager.create=true . | yq 'select(.kind == "ValidatingWebhookConfiguration") | .metadata.annotations'
cert-manager.io/inject-ca-from: /strimzi-drain-cleaner
# It should be
# cert-manager.io/inject-ca-from: release-ns/strimzi-drain-cleaner
```
As well as: 
```
$ helm template --namespace release-ns --set namespace.name="" --set certManager.create=true . | yq 'select(.kind == "Certificate") | .spec.dnsNames'
- strimzi-drain-cleaner..svc
- strimzi-drain-cleaner.
- strimzi-drain-cleaner
# It should be :
# - strimzi-drain-cleaner.release-ns.svc
# - strimzi-drain-cleaner.release-ns
# - strimzi-drain-cleaner
```
