### PR TITLE
Update quarkus to the latest LTS release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,10 +107,10 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     
     <!-- Quarkus -->
-    <quarkus-plugin.version>3.8.5</quarkus-plugin.version>
+    <quarkus-plugin.version>3.15.3</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.8.5</quarkus.platform.version>
+    <quarkus.platform.version>3.15.3</quarkus.platform.version>
 
     <!-- Other versions - used in Test -->
     <log4j.version>2.17.2</log4j.version>


### PR DESCRIPTION
This PR updates Quarkus version to the latest LTS version (3.15.3). This should address a Medium Netty CVE in Quarkus 3.8.