### PR TITLE
Use Maven@4 plugin in Azure pipelines

### DIFF
--- a/.azure/templates/jobs/run_systemtests.yaml
+++ b/.azure/templates/jobs/run_systemtests.yaml
@@ -36,9 +36,9 @@ jobs:
         env:
           BUILD_TAG: latest-$(arch)
         displayName: 'Docker load & tag & push to local registries - $(arch)'
-      - task: Maven@3
+      - task: Maven@4
         inputs:
-          mavenPomFile: 'pom.xml'
+          mavenPOMFile: 'pom.xml'
           publishJUnitResults: true
           goals: 'verify'
           options: '-B -Psystemtest'
@@ -47,9 +47,9 @@ jobs:
           DOCKER_TAG: $(docker_tag)
           TEST_LOG_DIR: $(test_log_dir)
         displayName: 'Run systemtests - $(arch) - Bundle installation'
-      - task: Maven@3
+      - task: Maven@4
         inputs:
-          mavenPomFile: 'pom.xml'
+          mavenPOMFile: 'pom.xml'
           publishJUnitResults: true
           goals: 'verify'
           options: '-B -Psystemtest'


### PR DESCRIPTION
The Maven@3 plugin used currently in the Drain Cleaner Azure pipelines is deprecated. This PR updates it to Maven@4.