### PR TITLE
Bump main branch to 1.4.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>io.strimzi</groupId>
   <artifactId>strimzi-drain-cleaner</artifactId>
-  <version>1.3.0-SNAPSHOT</version>
+  <version>1.4.0-SNAPSHOT</version>
 
   <licenses>
     <license>


### PR DESCRIPTION
As the 1.3.0 release is now branched, we can bump the version in the main branch to 1.4.0-SNAPSHOT.