### PR TITLE
Bump Quarkus to 3.15.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
     <quarkus-plugin.version>3.15.3</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.15.3</quarkus.platform.version>
+    <quarkus.platform.version>3.15.3.1</quarkus.platform.version>
 
     <!-- Other versions - used in Test -->
     <log4j.version>2.17.2</log4j.version>


### PR DESCRIPTION
This PR bumps Quakurs to 3.15.3.1 in order to fix Netty CVE - https://nvd.nist.gov/vuln/detail/CVE-2025-24970
Taken from https://quarkus.io/blog/cve-fixes-feb-2025/