### PR TITLE
Update Chart.yaml for Helm during make release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,8 @@ release_version:
 	echo "Changing Docker image tags in Helm Chart to :$(RELEASE_VERSION)"
 	CHART_PATH=./packaging/helm-charts/helm3/strimzi-drain-cleaner; \
 	$(SED) -i 's/\(tag: \).*/\1$(RELEASE_VERSION)/g' $$CHART_PATH/values.yaml; \
+	$(SED) -i 's/\(appVersion: \).*/\1$(RELEASE_VERSION)/g' $$CHART_PATH/Chart.yaml; \
+	$(SED) -i 's/\(version: \).*/\1$(RELEASE_VERSION)/g' $$CHART_PATH/Chart.yaml; \
 	$(SED) -i 's/\(image.tag[^\n]*| \)`.*`/\1`$(RELEASE_VERSION)`/g' $$CHART_PATH/README.md
 
 release_maven:


### PR DESCRIPTION
Currently, when we do `RELEASE_VERSION=X.X.X make release` everything is updated, but the `appVersion` and `version` in the Chart.yaml is not -> it should reflect the version of the application that this chart contains.

This PR adds two `sed`s for changing these values as well.