### PR TITLE
Use Quarkus 3.20 platform, update Surefire, remove superfluous versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,7 @@
 
     <!-- Other versions - used in Test -->
     <log4j.version>2.24.3</log4j.version>
+    <bouncycastle.version>1.80</bouncycastle.version>
     <skodjob.test-frame.version>0.8.0</skodjob.test-frame.version>
   </properties>
   <dependencyManagement>
@@ -177,16 +178,19 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk18on</artifactId>
+      <version>${bouncycastle.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk18on</artifactId>
+      <version>${bouncycastle.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcutil-jdk18on</artifactId>
+      <version>${bouncycastle.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
     <!-- Maven plugins -->
     <compiler-plugin.version>3.10.1</compiler-plugin.version>
     <maven.checkstyle.version>3.2.0</maven.checkstyle.version>
-    <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
+    <surefire-plugin.version>3.5.2</surefire-plugin.version>
 
     <!-- Project options -->
     <maven.compiler.parameters>true</maven.compiler.parameters>
@@ -105,20 +105,15 @@
     <maven.compiler.target>17</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    
+
     <!-- Quarkus -->
-    <quarkus-plugin.version>3.15.3</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.15.3.1</quarkus.platform.version>
+    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+    <quarkus.platform.version>3.20.0</quarkus.platform.version>
 
     <!-- Other versions - used in Test -->
-    <log4j.version>2.17.2</log4j.version>
-    <bouncycastle.version>1.78.1</bouncycastle.version>
+    <log4j.version>2.24.3</log4j.version>
     <skodjob.test-frame.version>0.8.0</skodjob.test-frame.version>
-
-    <!-- Used to override Quarkus Kubernetes Client dependency due to CVE-2024-26308 -->
-    <commons-compress.version>1.26.0</commons-compress.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -163,12 +158,6 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-resteasy-jackson</artifactId>
     </dependency>
-    <!-- Used to override Quarkus Kubernetes Client dependency due to CVE-2024-26308 -->
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-compress</artifactId>
-      <version>${commons-compress.version}</version>
-    </dependency>
     <dependency>
       <groupId>org.jboss.logmanager</groupId>
       <artifactId>log4j2-jboss-logmanager</artifactId>
@@ -177,7 +166,6 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
-      <version>${log4j.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -189,19 +177,16 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk18on</artifactId>
-      <version>${bouncycastle.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk18on</artifactId>
-      <version>${bouncycastle.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcutil-jdk18on</artifactId>
-      <version>${bouncycastle.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -233,7 +218,7 @@
                     <headerLocation>.checkstyle/java.header</headerLocation>
                     <suppressionsLocation>.checkstyle/suppressions.xml</suppressionsLocation>
                     <includeTestSourceDirectory>true</includeTestSourceDirectory>
-                    <encoding>UTF-8</encoding>
+                    <inputEncoding>UTF-8</inputEncoding>
                     <consoleOutput>true</consoleOutput>
                     <failsOnError>true</failsOnError>
                 </configuration>
@@ -244,9 +229,9 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>io.quarkus</groupId>
+        <groupId>${quarkus.platform.group-id}</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
-        <version>${quarkus-plugin.version}</version>
+        <version>${quarkus.platform.version}</version>
         <extensions>true</extensions>
         <executions>
           <execution>
@@ -326,9 +311,9 @@
       <build>
         <plugins>
           <plugin>
-            <groupId>io.quarkus</groupId>
+            <groupId>${quarkus.platform.group-id}</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>${quarkus-plugin.version}</version>
+            <version>${quarkus.platform.version}</version>
             <extensions>true</extensions>
             <executions>
               <execution>


### PR DESCRIPTION
- Updating to latest Quarkus LTS
- Use the platform groupId for Quarkus BOM and plugin (consolidate to unified version number for both)
- Clean up versions for other dependencies managed by Quarkus platform BOM