### PR TITLE
feat(helm): Allow overriding the validating webhook failurePolicy

### DIFF
--- a/packaging/helm-charts/helm3/strimzi-drain-cleaner/README.md
+++ b/packaging/helm-charts/helm3/strimzi-drain-cleaner/README.md
@@ -37,7 +37,7 @@ spec:
         type: persistent-claim
         size: 100Gi
         deleteClaim: false
-    # Uncomment when using the legacy mode 
+    # Uncomment when using the legacy mode
     # template:
     #   podDisruptionBudget:
     #     maxUnavailable: 0
@@ -47,7 +47,7 @@ spec:
       type: persistent-claim
       size: 100Gi
       deleteClaim: false
-    # Uncomment when using the legacy mode 
+    # Uncomment when using the legacy mode
     # template:
     #   podDisruptionBudget:
     #     maxUnavailable: 0
@@ -179,6 +179,7 @@ For a full list of supported options, check the [`values.yaml` file](./values.ya
 | `affinity`               | Add affinities to Drain Cleaner Pod                                    | `{}`            |
 | `nodeSelector`           | Add a node selector to Drain Cleaner Pod                               | `{}`            |
 | `deploymentStrategy`     | Adjust the Kubernetes rollout strategy of the Drain Cleaner Deployment | `{}`            |
+| `webhook.faillurePolicy` | Override default validating webhook failurePolicy                      | `Ignore`        |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/packaging/helm-charts/helm3/strimzi-drain-cleaner/templates/070-ValidatingWebhookConfiguration.yaml
+++ b/packaging/helm-charts/helm3/strimzi-drain-cleaner/templates/070-ValidatingWebhookConfiguration.yaml
@@ -27,9 +27,9 @@ webhooks:
       {{- end }}
     admissionReviewVersions: ["v1"]
     {{- with (.Values.webhook).namespaceSelector }}
-    namespaceSelector: 
+    namespaceSelector:
       {{- toYaml . | nindent 6 }}
     {{- end }}
     sideEffects: None
-    failurePolicy: Ignore
+    failurePolicy: {{ .Values.webhook.failurePolicy }}
     timeoutSeconds: 5

--- a/packaging/helm-charts/helm3/strimzi-drain-cleaner/values.yaml
+++ b/packaging/helm-charts/helm3/strimzi-drain-cleaner/values.yaml
@@ -99,3 +99,6 @@ env:
     valueFrom:
       fieldRef:
         fieldPath: metadata.name
+
+webhook:
+  failurePolicy: Ignore


### PR DESCRIPTION
# Description
Allow overriding validating webhook `failurePolicy`.
By default, the `failurePolicy` remains set to `Ignore` to keep the existing behavior

# Motivation
Currently, the validating webhook's `failurePolicy` is hardcoded to `Ignore`. This means that if the drain-cleaner is unavailable, the Kubernetes API server will ignore the failure and allow the request to proceed. This can cause unexpected evictions on Strimzi pods.

In order to better tolerate drain-cleaner downtime, I'd like to be able to set `failurePolicy` to `Fail` value.