### PR TITLE
Update main branch to 1.5.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>io.strimzi</groupId>
   <artifactId>strimzi-drain-cleaner</artifactId>
-  <version>1.4.0-SNAPSHOT</version>
+  <version>1.5.0-SNAPSHOT</version>
 
   <licenses>
     <license>


### PR DESCRIPTION
The 1.4.0 release has it's own release branch, so this PR updates the `main` branch to `1.5.0-SNAPSHOT` version.