### PR TITLE
Bump Quarkus version to 3.20.2 after release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <!-- Quarkus -->
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.20.1</quarkus.platform.version>
+    <quarkus.platform.version>3.20.2</quarkus.platform.version>
 
     <!-- Other versions - used in Test -->
     <log4j.version>2.24.3</log4j.version>


### PR DESCRIPTION
This PR updates version of Quarkus to 3.20.2 after the release.
