### PR TITLE
Replace RESTEasy Classic with Quarkus REST

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,11 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-resteasy</artifactId>
+      <artifactId>quarkus-rest</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-rest-jackson</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
@@ -100,10 +104,6 @@
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-resteasy-jackson</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jboss.logmanager</groupId>


### PR DESCRIPTION
Replace the use of RESTEasy Classic (quarkus-resteasy* dependencies) with the newer Quarkus REST (quarkus-rest* dependencies). This is now the recommended Jakarta REST implementation for use in Quarkus applications [1][2]

[1] https://quarkus.io/guides/resteasy
[2] https://quarkus.io/guides/rest