### PR TITLE
Fix docker manifests push after docker upgrade

### DIFF
--- a/.azure/scripts/install_syft.sh
+++ b/.azure/scripts/install_syft.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-readonly VERSION="0.90.0"
+readonly VERSION="1.20.0"
 
 ARCH=$1
 if [ -z "$ARCH" ]; then

--- a/.azure/templates/jobs/push_container.yaml
+++ b/.azure/templates/jobs/push_container.yaml
@@ -30,17 +30,9 @@ jobs:
           DOCKER_USER: $(QUAY_USER)
           DOCKER_PASS: $(QUAY_PASS)
           DOCKER_REGISTRY: "quay.io"
-      - bash: "make docker_delete_manifest"
-        displayName: "Delete existing container manifest"
-        env:
-          BUILD_REASON: $(Build.Reason)
-          BRANCH: $(Build.SourceBranch)
-          DOCKER_REGISTRY: "quay.io"
-          DOCKER_ORG: "strimzi"
-          DOCKER_TAG: '${{ parameters.dockerTag }}'
       - ${{ each arch in parameters.architectures }}:
-          - bash: make docker_load docker_tag docker_push docker_amend_manifest docker_delete_archive
-            displayName: "Push the ${{ arch }} containers and create manifest"
+          - bash: make docker_load docker_tag docker_push docker_delete_archive
+            displayName: "Push the ${{ arch }} containers"
             env:
               BUILD_REASON: $(Build.Reason)
               BRANCH: $(Build.SourceBranch)
@@ -48,14 +40,15 @@ jobs:
               DOCKER_ORG: "strimzi"
               DOCKER_TAG: '${{ parameters.dockerTag }}'
               DOCKER_ARCHITECTURE: ${{ arch }}
-      - bash: "make docker_push_manifest"
-        displayName: "Push container manifest"
+      - bash: "make docker_amend_manifest"
+        displayName: "Create multi-platform manifests"
         env:
           BUILD_REASON: $(Build.Reason)
           BRANCH: $(Build.SourceBranch)
           DOCKER_REGISTRY: "quay.io"
           DOCKER_ORG: "strimzi"
           DOCKER_TAG: '${{ parameters.dockerTag }}'
+          MANIFEST_ARCHITECTURES: '${{ join('','', parameters.architectures) }}'
       - bash: "make docker_sign_manifest"
         displayName: "Sign container manifest"
         env:

--- a/.azure/templates/steps/prerequisites/install_docker.yaml
+++ b/.azure/templates/steps/prerequisites/install_docker.yaml
@@ -4,7 +4,7 @@ steps:
     displayName: Install Docker
     inputs:
       # Versions can be found from https://download.docker.com/linux/static/stable/x86_64/
-      dockerVersion: 24.0.5
+      dockerVersion: 29.2.0
       releaseType: stable
   - bash: |
       docker run --rm --privileged multiarch/qemu-user-static --reset -p yes

--- a/.github/actions/build/push-containers/action.yml
+++ b/.github/actions/build/push-containers/action.yml
@@ -67,32 +67,26 @@ runs:
       shell: bash
       run: docker login -u ${{ inputs.quayUser }} -p ${{ inputs.quayPass }} ${{ env.DOCKER_REGISTRY }}
 
-    - name: Delete existing container manifests
-      shell: bash
-      run: make docker_delete_manifest
-      env:
-        BUILD_REASON: "IndividualCI"
-        BRANCH: ${{ github.ref }}
-
-    - name: Push containers and create manifests
+    - name: Push containers
       shell: bash
       run: |
         IFS=',' read -ra ARCH_ARRAY <<< "${{ inputs.architectures }}"
         for arch in "${ARCH_ARRAY[@]}"; do
           echo "Processing architecture: ${arch}"
           export DOCKER_ARCHITECTURE="${arch}"
-          make docker_load docker_tag docker_push docker_amend_manifest docker_delete_archive
+          make docker_load docker_tag docker_push docker_delete_archive
         done
       env:
         BUILD_REASON: "IndividualCI"
         BRANCH: ${{ github.ref }}
 
-    - name: Push container manifests
+    - name: Create multi-platform manifests
       shell: bash
-      run: make docker_push_manifest
+      run: make docker_amend_manifest
       env:
         BUILD_REASON: "IndividualCI"
         BRANCH: ${{ github.ref }}
+        MANIFEST_ARCHITECTURES: ${{ inputs.architectures }}
 
     - name: Sign container manifests
       shell: bash

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -22,6 +22,8 @@ ifdef DOCKER_ARCHITECTURE
   SBOM_DIR=$(TOPDIR)sbom/$(DOCKER_ARCHITECTURE)
 endif
 
+MANIFEST_ARCHITECTURES ?= $(DOCKER_ARCHITECTURE)
+
 .PHONY: docker_build
 docker_build:
 	# Build Docker image ...
@@ -35,7 +37,7 @@ docker_build:
 .PHONY: docker_save
 docker_save:
 	# Saves the container as TGZ file
-	docker save strimzi/$(PROJECT_NAME):$(BUILD_TAG)$(DOCKER_PLATFORM_TAG_SUFFIX) | gzip > drain-cleaner-container$(DOCKER_PLATFORM_TAG_SUFFIX).tar.gz
+	docker save $(DOCKER_PLATFORM) strimzi/$(PROJECT_NAME):$(BUILD_TAG)$(DOCKER_PLATFORM_TAG_SUFFIX) | gzip > drain-cleaner-container$(DOCKER_PLATFORM_TAG_SUFFIX).tar.gz
 
 .PHONY: docker_load
 docker_load:
@@ -59,18 +61,12 @@ docker_delete_archive:
 
 .PHONY: docker_amend_manifest
 docker_amend_manifest:
-	# Create / Amend the manifest
-	docker manifest create $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG) --amend $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG)$(DOCKER_PLATFORM_TAG_SUFFIX)
-
-.PHONY: docker_push_manifest
-docker_push_manifest:
-	# Push the manifest to the registry
-	docker manifest push $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG)
-
-.PHONY: docker_delete_manifest
-docker_delete_manifest:
-	# Delete the manifest to the registry, ignore the error if manifest doesn't exist
-	docker manifest rm $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG) || true
+	# Create the multi-platform manifest from architecture-specific images
+	sources="" ; \
+	for arch in $$(echo "$(MANIFEST_ARCHITECTURES)" | tr ',' ' '); do \
+		sources="$$sources $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG)-$$arch" ; \
+	done ; \
+	docker buildx imagetools create -t $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG) $$sources
 
 .PHONY: docker_sign_manifest
 docker_sign_manifest:


### PR DESCRIPTION
It seems that github runners updated docker version to 29.1.5 recently. The bumpd from previous version introduced breaking changes for manifest manipulation and because we use quite old approach it starting to fail the builds. This PR switch to use buildx imagetools from manifest manipulation and update syft version to work properly with the docker version.

Same as https://github.com/strimzi/strimzi-kafka-operator/pull/12416