### PR TITLE
Fix naming of artifacts for CVE/Release workflows

### DIFF
--- a/.github/workflows/cve-rebuild.yml
+++ b/.github/workflows/cve-rebuild.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Pull Java artifacts from GHCR
         run: |
-          oras pull ghcr.io/${{ env.REPOSITORY }}/drain-cleaner-binaries:${{ env.TAG }}
+          oras pull ghcr.io/${{ env.REPOSITORY }}/binaries-drain-cleaner:${{ env.TAG }}
         env:
           TAG: ${{ inputs.releaseVersion }}-${{ inputs.sourceBuildRunId }}
           REPOSITORY: "strimzi"
@@ -47,8 +47,8 @@ jobs:
       - name: Upload as workflow artifact
         uses: actions/upload-artifact@v5
         with:
-          name: drain-cleaner-binaries.tar
-          path: drain-cleaner-binaries.tar
+          name: binaries-drain-cleaner.tar
+          path: binaries-drain-cleaner.tar
 
   build-containers:
     name: Build Containers

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Download strimzi binaries from source build
         uses: actions/download-artifact@v7
         with:
-          name: drain-cleaner-binaries.tar
+          name: binaries-drain-cleaner.tar
           run-id: ${{ inputs.sourceBuildRunId }}
           github-token: ${{ github.token }}
 
@@ -72,7 +72,7 @@ jobs:
 
       - name: Push Java artifacts to GHCR
         run: |
-          oras push ghcr.io/${{ env.REPOSITORY }}/drain-cleaner-binaries:${{ env.TAG }} drain-cleaner-binaries.tar:application/x-tar
+          oras push ghcr.io/${{ env.REPOSITORY }}/binaries-drain-cleaner:${{ env.TAG }} binaries-drain-cleaner.tar:application/x-tar
         env:
           TAG: ${{ inputs.releaseVersion }}-${{ inputs.sourceBuildRunId }}
           REPOSITORY: "strimzi"


### PR DESCRIPTION
During 1st release of Bridge we found out that we had wrong names for artifacts within CVE and release workflows. This PR fixes it in drain-cleaner repo.