### PR TITLE
[ST] Replace Test-Frame with Kubetest4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <!-- Other versions - used in Test -->
     <log4j.version>2.25.4</log4j.version>
     <bouncycastle.version>1.84</bouncycastle.version>
-    <skodjob.test-frame.version>1.0.0</skodjob.test-frame.version>
+    <skodjob.kubetest4j.version>1.1.0</skodjob.kubetest4j.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -139,9 +139,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.skodjob</groupId>
-      <artifactId>test-frame-log-collector</artifactId>
-      <version>${skodjob.test-frame.version}</version>
+      <groupId>io.skodjob.kubetest4j</groupId>
+      <artifactId>log-collector</artifactId>
+      <version>${skodjob.kubetest4j.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/test/java/io/strimzi/utils/logs/TestLogCollector.java
+++ b/src/test/java/io/strimzi/utils/logs/TestLogCollector.java
@@ -4,10 +4,10 @@
  */
 package io.strimzi.utils.logs;
 
-import io.skodjob.testframe.LogCollector;
-import io.skodjob.testframe.LogCollectorBuilder;
-import io.skodjob.testframe.clients.KubeClient;
-import io.skodjob.testframe.clients.cmdClient.Kubectl;
+import io.skodjob.kubetest4j.LogCollector;
+import io.skodjob.kubetest4j.LogCollectorBuilder;
+import io.skodjob.kubetest4j.clients.KubeClient;
+import io.skodjob.kubetest4j.clients.cmdClient.Kubectl;
 import io.strimzi.utils.Constants;
 import io.strimzi.utils.Environment;
 


### PR DESCRIPTION
This PR replaces Test-Frame with Kubetest4j - which is actually Test-Frame, but we decided to move the whole logic to new repository with better name. It also bumps the dependency to latest release.