### PR TITLE
Update Quarkus to new LTS version 3.33.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <!-- Quarkus -->
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.3</quarkus.platform.version>
+    <quarkus.platform.version>3.33.1</quarkus.platform.version>
 
     <!-- Other versions - used in Test -->
     <log4j.version>2.25.4</log4j.version>


### PR DESCRIPTION
This small PR moves Quarkus to 3.33.1 - which is the new LTS.