### PR TITLE
Move main branch to 1.7.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>io.strimzi</groupId>
   <artifactId>strimzi-drain-cleaner</artifactId>
-  <version>1.6.0-SNAPSHOT</version>
+  <version>1.7.0-SNAPSHOT</version>
 
   <licenses>
     <license>


### PR DESCRIPTION
This PR moves main to `1.7.0-SNAPSHOT` after creating release branch for 1.6.0