### PR TITLE
Add enableServiceLinks support to Helm chart

### DIFF
--- a/packaging/helm-charts/helm3/strimzi-drain-cleaner/templates/060-Deployment.yaml
+++ b/packaging/helm-charts/helm3/strimzi-drain-cleaner/templates/060-Deployment.yaml
@@ -34,6 +34,9 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- end }}
+      {{- if kindIs "bool" .Values.enableServiceLinks }}
+      enableServiceLinks: {{ .Values.enableServiceLinks }}
+      {{- end }}
       containers:
         - name: strimzi-drain-cleaner
           image: {{ .Values.image.registry }}/{{ .Values.image.repository}}/{{ .Values.image.name }}:{{ .Values.image.tag }}

--- a/packaging/helm-charts/helm3/strimzi-drain-cleaner/values.yaml
+++ b/packaging/helm-charts/helm3/strimzi-drain-cleaner/values.yaml
@@ -62,6 +62,8 @@ securityContext: {}
   # Specifies optional security context, depending your environment prerequisites.
   # If you want to specify security contexts add them below and remove curly braces above.
 
+enableServiceLinks: NULL
+
 podSecurityContext: {}
   # Specifies optional pod security context, depending your environment prerequisites.
   # If you want to specify pod security contexts add them below and remove curly braces above.


### PR DESCRIPTION
## Description

Add `enableServiceLinks` as a configurable value in the Helm chart, allowing users to control whether Kubernetes injects service environment variables into pods.

### Changes

- **values.yaml**: Added `enableServiceLinks: NULL` (default omits the field)
- **060-Deployment.yaml**: Added conditional rendering using `kindIs "bool"` guard, only rendering when explicitly set to `true` or `false`

### Usage

```yaml
enableServiceLinks: false
```

This follows the same pattern used by the [strimzi-kafka-operator Helm chart](https://github.com/strimzi/strimzi-kafka-operator/blob/main/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml#L60-L62).