### PR TITLE
Add configurable sizeLimit for the /tmp emptyDir volume

### DIFF
--- a/packaging/helm-charts/helm3/strimzi-drain-cleaner/README.md
+++ b/packaging/helm-charts/helm3/strimzi-drain-cleaner/README.md
@@ -185,6 +185,7 @@ For a full list of supported options, check the [`values.yaml` file](./values.ya
 | `webhook.timeoutSeconds` | Override default validating webhook timeoutSeconds                     | `5`             |
 | `securityContext`        | Set the security context for the Drain Cleaner container               | `{}`            |
 | `podSecurityContext`     | Set the pod security context for the Drain Cleaner pod                 | `{}`            |
+| `tmpDirSizeLimit`        | Size limit for the `/tmp` emptyDir volume; empty string = no limit      | `5Mi`           |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/packaging/helm-charts/helm3/strimzi-drain-cleaner/templates/060-Deployment.yaml
+++ b/packaging/helm-charts/helm3/strimzi-drain-cleaner/templates/060-Deployment.yaml
@@ -107,7 +107,12 @@ spec:
           secret:
             secretName: strimzi-drain-cleaner
         - name: tmp-dir
+          {{- if .Values.tmpDirSizeLimit }}
+          emptyDir:
+            sizeLimit: {{ .Values.tmpDirSizeLimit | quote }}
+          {{- else }}
           emptyDir: {}
+          {{- end }}
   {{- with .Values.deploymentStrategy }}
   strategy:
     {{- toYaml . | trim | nindent 4 }}

--- a/packaging/helm-charts/helm3/strimzi-drain-cleaner/values.yaml
+++ b/packaging/helm-charts/helm3/strimzi-drain-cleaner/values.yaml
@@ -58,6 +58,13 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
+# Size limit for the `/tmp` emptyDir volume mounted into the Drain Cleaner Pod.
+# Defaults to `5Mi`, which is ample for the JVM `hsperfdata` and Vert.x/Quarkus
+# temp cache that are the only things written there. Set an empty string to
+# render the volume as `emptyDir: {}` (no size limit). Mirrors the
+# `tmpDirSizeLimit` option of the strimzi-kafka-operator Helm chart.
+tmpDirSizeLimit: 5Mi
+
 securityContext: {}
   # Specifies optional security context, depending your environment prerequisites.
   # If you want to specify security contexts add them below and remove curly braces above.


### PR DESCRIPTION
#### Type of change

- Enhancement / new feature

#### Description

The Drain Cleaner Pod mounts an `emptyDir` volume at `/tmp`, which the Helm chart previously hardcoded as `emptyDir: {}` with no way to set a `sizeLimit`.

Some Kubernetes clusters enforce admission policies that require every writable `emptyDir` volume to declare a `sizeLimit`. On such clusters the chart could not be deployed as-is — the only workarounds are forking/vendoring the chart or applying a post-render patch, neither of which is great for a maintained GitOps setup.

This adds a configurable `tmpDirSizeLimit` value to the chart:

- **Defaults to `5Mi`**, which is ample for the JVM `hsperfdata` and Vert.x/Quarkus temp cache that are the only things written to `/tmp`.
- **Set to an empty string** to render the volume as `emptyDir: {}` (no size limit).

The value name mirrors the `tmpDirSizeLimit` option that already exists in the `strimzi-kafka-operator` Helm chart, keeping the configuration consistent across Strimzi charts.

Only the editable chart under `packaging/helm-charts/helm3/strimzi-drain-cleaner/` is modified; the release-only copy under `helm-charts/` is left untouched per its `DO_NOT_EDIT.md`.

#### AI assistance disclosure

This PR was prepared with AI assistance (Cursor). I have reviewed and understand all of the changes, verified them myself, and take full ownership of the contribution, in line with the [Strimzi AI Contribution Policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md). No AI tooling has been added to any commit trailer.

#### Checklist

- [x] `helm lint` passes
- [x] `helm template` with the default values renders `sizeLimit: 5Mi`
- [x] `helm template --set tmpDirSizeLimit=""` renders `emptyDir: {}`
- [x] `README.md` configuration table updated
- [x] Commit is signed off (DCO)
- [x] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))